### PR TITLE
added FutureWarning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 
 Changelog
 =========
+2.5.2 (2019)
+-----------------------------------------
+* Added FutureWarning to deprecated functions
+* Updated names in licenses
+* Moved module structure routine tests to their own class
+
+
 2.5.1 (2018-10-19)
 -----------------------------------------
 * Commented out debug statement in C code

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -22,8 +22,6 @@ import numpy as np
 import logbook as logging
 import warnings
 
-dstr = "This routine has been deprecated and may be removed in future versions"
-
 def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
             badidea=False, geocentric=False):
     """Converts between geomagnetic coordinates and AACGM coordinates
@@ -59,6 +57,8 @@ def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
     """
     import aacgmv2
 
+    dstr = "Deprecated routine, may be removed in future versions.  Recommend "
+    dstr += "using convert_latlon or convert_latlon_arr"
     warnings.warn(dstr, category=FutureWarning)
 
     if(np.array(alt).max() > 2000 and not trace and not allowtrace and
@@ -114,6 +114,7 @@ def subsol(year, doy, utime):
     After Fortran code by A. D. Richmond, NCAR. Translated from IDL
     by K. Laundal.
     """
+    dstr = "Deprecated routine, may be removed in future versions"
     warnings.warn(dstr, category=FutureWarning)
 
     
@@ -185,6 +186,7 @@ def gc2gd_lat(gc_lat):
     gd_lat : (same as input)
         Geodetic latitude in degrees N
     """
+    dstr = "Deprecated routine, may be removed in future versions"
     warnings.warn(dstr, category=FutureWarning)
 
     
@@ -215,6 +217,7 @@ def igrf_dipole_axis(date):
     import datetime as dt
     import aacgmv2
 
+    dstr = "Deprecated routine, may be removed in future versions"
     warnings.warn(dstr, category=FutureWarning)
 
 

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -20,6 +20,7 @@ Laundal, K. M. and A. D. Richmond (2016), Magnetic Coordinate Systems, Space
 from __future__ import division, absolute_import, unicode_literals
 import numpy as np
 import logbook as logging
+import warnings
 
 dstr = "This routine has been deprecated and may be removed in future versions"
 
@@ -57,8 +58,8 @@ def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
         Output longitude in degrees E
     """
     import aacgmv2
-    dstr += ", recommend using convert_latlon or convert_latlon_arr instead"
-    raise FutureWarning(dstr)
+
+    warnings.warn(dstr, category=FutureWarning)
 
     if(np.array(alt).max() > 2000 and not trace and not allowtrace and
        not badidea):
@@ -113,7 +114,8 @@ def subsol(year, doy, utime):
     After Fortran code by A. D. Richmond, NCAR. Translated from IDL
     by K. Laundal.
     """
-    raise FutureWarning(dstr)
+    warnings.warn(dstr, category=FutureWarning)
+
     
     yr2 = year - 2000
 
@@ -183,7 +185,8 @@ def gc2gd_lat(gc_lat):
     gd_lat : (same as input)
         Geodetic latitude in degrees N
     """
-    raise FutureWarning(dstr)
+    warnings.warn(dstr, category=FutureWarning)
+
     
     wgs84_e2 = 0.006694379990141317 - 1.0
     return np.rad2deg(-np.arctan(np.tan(np.deg2rad(gc_lat)) / wgs84_e2))
@@ -212,7 +215,8 @@ def igrf_dipole_axis(date):
     import datetime as dt
     import aacgmv2
 
-    raise FutureWarning(dstr)
+    warnings.warn(dstr, category=FutureWarning)
+
 
     # get time in years, as float:
     year = date.year

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -21,6 +21,8 @@ from __future__ import division, absolute_import, unicode_literals
 import numpy as np
 import logbook as logging
 
+dstr = "This routine has been deprecated and may be removed in future versions"
+
 def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
             badidea=False, geocentric=False):
     """Converts between geomagnetic coordinates and AACGM coordinates
@@ -55,6 +57,8 @@ def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
         Output longitude in degrees E
     """
     import aacgmv2
+    dstr += ", recommend using convert_latlon or convert_latlon_arr instead"
+    raise FutureWarning(dstr)
 
     if(np.array(alt).max() > 2000 and not trace and not allowtrace and
        not badidea):
@@ -109,6 +113,8 @@ def subsol(year, doy, utime):
     After Fortran code by A. D. Richmond, NCAR. Translated from IDL
     by K. Laundal.
     """
+    raise FutureWarning(dstr)
+    
     yr2 = year - 2000
 
     if year >= 2101:
@@ -177,6 +183,8 @@ def gc2gd_lat(gc_lat):
     gd_lat : (same as input)
         Geodetic latitude in degrees N
     """
+    raise FutureWarning(dstr)
+    
     wgs84_e2 = 0.006694379990141317 - 1.0
     return np.rad2deg(-np.arctan(np.tan(np.deg2rad(gc_lat)) / wgs84_e2))
 
@@ -203,6 +211,8 @@ def igrf_dipole_axis(date):
     """
     import datetime as dt
     import aacgmv2
+
+    raise FutureWarning(dstr)
 
     # get time in years, as float:
     year = date.year

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -23,18 +23,6 @@ class TestCAACGMV2:
         del self.date_args, self.long_date, self.mlat, self.mlon, self.mlt
         del self.lat_in, self.lon_in, self.alt_in
 
-    @classmethod
-    def test_module_structure(self):
-        """Test module structure"""
-        assert aacgmv2
-        assert aacgmv2._aacgmv2
-        assert aacgmv2._aacgmv2.set_datetime
-        assert aacgmv2._aacgmv2.convert
-        assert aacgmv2._aacgmv2.inv_mlt_convert
-        assert aacgmv2._aacgmv2.inv_mlt_convert_yrsec
-        assert aacgmv2._aacgmv2.mlt_convert
-        assert aacgmv2._aacgmv2.mlt_convert_yrsec
-
     def test_constants(self):
         """Test module constants"""
         ans1 = aacgmv2._aacgmv2.G2A == 0

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -32,7 +32,7 @@ class TestFutureDepWarning:
                 # Verify some things
                 assert len(w) == 1
                 assert issubclass(w[-1].category, FutureWarning)
-                assert "deprecated and may be removed" in str(w[-1].message)
+                assert "Deprecated routine" in str(w[-1].message)
 
 
 class TestDepAACGMV2Warning(TestFutureDepWarning):

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -5,7 +5,76 @@ import datetime as dt
 import numpy as np
 import pytest
 import aacgmv2
+import warnings
 
+class TestFutureDepWarning:
+    def setup(self):
+        # Initialize the routine to be tested
+        self.test_routine = None
+        self.test_args = []
+        self.test_kwargs = {}
+
+    def teardown(self):
+        del self.test_routine, self.test_args, self.test_kwargs
+
+    def test_future_dep_warning(self):
+        """Test the implementation of FutureWarning for deprecated routines"""
+        if self.test_routine is None:
+            assert True
+        else:
+            with warnings.catch_warnings(record=True) as w:
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+
+                # Trigger a warning.
+                self.test_routine(*self.test_args, **self.test_kwargs)
+
+                # Verify some things
+                assert len(w) == 1
+                assert issubclass(w[-1].category, FutureWarning)
+                assert "deprecated and may be removed" in str(w[-1].message)
+
+
+class TestDepAACGMV2Warning(TestFutureDepWarning):
+    def setup(self):
+        self.dtime = dt.datetime(2015, 1, 1, 0, 0, 0)
+        self.test_routine = None
+        self.test_args = []
+        self.test_kwargs = {}
+
+    def teardown(self):
+        del self.dtime, self.test_routine, self.test_args, self.test_kwargs
+
+    def test_convert_warning(self):
+        """Test future deprecation warning for convert"""
+
+        self.test_routine = aacgmv2.deprecated.convert
+        self.test_args = [60, 0, 300, self.dtime]
+        self.test_future_dep_warning()
+
+    def test_subsol_warning(self):
+        """Test future deprecation warning for subsol"""
+
+        self.test_routine = aacgmv2.deprecated.subsol
+        self.test_args = [self.dtime.year, int(self.dtime.strftime("%j")),
+                          self.dtime.second + self.dtime.minute * 60 +
+                          self.dtime.hour * 3600]
+        self.test_future_dep_warning()
+
+    def test_gc2gd_lat_warning(self):
+        """Test future deprecation warning for gc2gd_lat"""
+
+        self.test_routine = aacgmv2.deprecated.gc2gd_lat
+        self.test_args = [60.0]
+        self.test_future_dep_warning()
+
+    def test_igrf_dipole_axis_warning(self):
+        """Test future deprecation warning for igrf_dipole_axis"""
+
+        self.test_routine = aacgmv2.deprecated.igrf_dipole_axis
+        self.test_args = [self.dtime]
+        self.test_future_dep_warning()
+        
 class TestDepAACGMV2:
     def setup(self):
         """Runs before every method to create a clean testing setup"""
@@ -18,19 +87,12 @@ class TestDepAACGMV2:
         """Runs after every method to clean up previous testing"""
         del self.dtime, self.ddate, self.lat, self.lon
 
-    @classmethod
-    def test_module_structure(self):
-        """Test module structure for deprecated routines"""
-        assert aacgmv2
-        assert aacgmv2.convert
-        assert aacgmv2.deprecated.subsol
-        assert aacgmv2.deprecated
-        assert aacgmv2.deprecated.gc2gd_lat
-        assert aacgmv2.deprecated.igrf_dipole_axis
-
     def test_convert_single_val(self):
         """Test conversion for a single value"""
-        self.lat, self.lon = aacgmv2.convert(60, 0, 300, self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert(60, 0, 300, self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
@@ -39,15 +101,21 @@ class TestDepAACGMV2:
 
     def test_convert_list(self):
         """Test conversion for list input"""
-        self.lat, self.lon = aacgmv2.convert([60], [0], [300], self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert([60], [0], [300], self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
 
-        self.lat, self.lon = aacgmv2.convert([60, 61], [0, 0], [300, 300],
-                                             self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert([60, 61], [0, 0], [300, 300],
+                                                 self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
@@ -56,8 +124,11 @@ class TestDepAACGMV2:
 
     def test_convert_arr_single(self):
         """Test conversion for array input with one element"""
-        self.lat, self.lon = aacgmv2.convert(np.array([60]), np.array([0]),
-                                   np.array([300]), self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert(np.array([60]), np.array([0]),
+                                                 np.array([300]), self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
@@ -66,9 +137,14 @@ class TestDepAACGMV2:
 
     def test_convert_arr(self):
         """Test conversion for array input"""
-        self.lat, self.lon = aacgmv2.convert(np.array([60, 61]),
-                                             np.array([0, 0]),
-                                             np.array([300, 300]), self.dtime)
+        
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert(np.array([60, 61]),
+                                                 np.array([0, 0]),
+                                                 np.array([300, 300]),
+                                                 self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
@@ -77,7 +153,11 @@ class TestDepAACGMV2:
 
     def test_convert_list_mix(self):
         """Test conversion for a list and floats"""
-        self.lat, self.lon = aacgmv2.convert([60, 61], 0, 300, self.dtime)
+        
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert([60, 61], 0, 300, self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
@@ -86,8 +166,11 @@ class TestDepAACGMV2:
 
     def test_convert_arr_mix(self):
         """Test conversion for an array and floats"""
-        self.lat, self.lon = aacgmv2.convert(np.array([60, 61]), 0, 300,
-                                             self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert(np.array([60, 61]), 0, 300,
+                                                 self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
@@ -96,9 +179,12 @@ class TestDepAACGMV2:
 
     def test_convert_mult_array_mix(self):
         """Test conversion for a multi-dim array and floats"""
-        self.lat, self.lon = aacgmv2.convert(np.array([[60, 61, 62],
-                                                       [63, 64, 65]]), 0,
-                                             300, self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert(np.array([[60, 61, 62],
+                                                           [63, 64, 65]]), 0,
+                                                 300, self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (2, 3)
@@ -111,10 +197,13 @@ class TestDepAACGMV2:
 
     def test_convert_unequal_arra(self):
         """Test conversion for unequal sized arrays"""
-        self.lat, self.lon = aacgmv2.convert(np.array([[60, 61, 62],
-                                                       [63, 64, 65]]),
-                                             np.array([0]), np.array([300]),
-                                             self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert(np.array([[60, 61, 62],
+                                                           [63, 64, 65]]),
+                                                 np.array([0]), np.array([300]),
+                                                 self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (2, 3)
@@ -127,7 +216,10 @@ class TestDepAACGMV2:
 
     def test_convert_location_failure(self):
         """Test conversion with a bad location"""
-        self.lat, self.lon = aacgmv2.convert([0], [0], [0], self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert([0], [0], [0], self.dtime)
+
         assert isinstance(self.lat, np.ndarray)
         assert isinstance(self.lon, np.ndarray)
         assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
@@ -136,11 +228,16 @@ class TestDepAACGMV2:
     def test_convert_time_failure(self):
         """Test conversion with a bad time"""
         with pytest.raises(AssertionError):
-            self.lat, self.lon = aacgmv2.convert([60], [0], [300], None)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self.lat, self.lon = aacgmv2.convert([60], [0], [300], None)
 
     def test_convert_datetime_date(self):
         """Test conversion with date and datetime input"""
-        self.lat, self.lon = aacgmv2.convert([60], [0], [300], self.ddate)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat, self.lon = aacgmv2.convert([60], [0], [300], self.ddate)
+
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
 
@@ -150,8 +247,11 @@ class TestDepAACGMV2:
         lwarn = u"conversion not intended for altitudes < 0 km"
 
         with logbook.TestHandler() as handler:
-            self.lat, self.lon = aacgmv2.convert([60], [0], [-1], self.dtime)
-            assert handler.has_warning(lwarn)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self.lat, self.lon = aacgmv2.convert([60], [0], [-1],
+                                                     self.dtime)
+                assert handler.has_warning(lwarn)
 
         handler.close()
 
@@ -159,46 +259,61 @@ class TestDepAACGMV2:
         """For an array, test failure for an altitude too high for
         coefficients"""
         with pytest.raises(ValueError):
-            aacgmv2.convert([60], [0], [2001], self.dtime)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                aacgmv2.convert([60], [0], [2001], self.dtime)
 
     def test_convert_lat_failure(self):
         """Test error return for co-latitudes above 90 for an array"""
         with pytest.raises(AssertionError):
-            aacgmv2.convert([91, 60, -91], 0, 300, self.dtime)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                aacgmv2.convert([91, 60, -91], 0, 300, self.dtime)
 
     def test_subsol(self):
         """Test the subsolar calculation"""
         doy = int(self.dtime.strftime("%j"))
         ut = self.dtime.hour * 3600.0 + self.dtime.minute * 60.0 + \
              self.dtime.second
-        self.lon, self.lat = aacgmv2.deprecated.subsol(self.dtime.year, doy, ut)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lon, self.lat = aacgmv2.deprecated.subsol(self.dtime.year,
+                                                           doy, ut)
 
         np.testing.assert_almost_equal(self.lon, -179.2004, decimal=4)
         np.testing.assert_almost_equal(self.lat, -23.0431, decimal=4)
 
     def test_gc2gd_lat(self):
         """Test the geocentric to geodetic conversion"""
-        self.lat = aacgmv2.deprecated.gc2gd_lat(45.0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat = aacgmv2.deprecated.gc2gd_lat(45.0)
 
         np.testing.assert_almost_equal(self.lat, 45.1924, decimal=4)
 
     def test_gc2gd_lat_list(self):
         """Test the geocentric to geodetic conversion"""
         self.lat = [45.0, -45.0]
-        self.lat = aacgmv2.deprecated.gc2gd_lat(self.lat)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat = aacgmv2.deprecated.gc2gd_lat(self.lat)
 
         np.testing.assert_allclose(self.lat, [45.1924, -45.1924], rtol=1.0e-4)
 
     def test_gc2gd_lat_arr(self):
         """Test the geocentric to geodetic conversion"""
         self.lat = np.array([45.0, -45.0])
-        self.lat = aacgmv2.deprecated.gc2gd_lat(self.lat)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            self.lat = aacgmv2.deprecated.gc2gd_lat(self.lat)
 
         np.testing.assert_allclose(self.lat, [45.1924, -45.1924], rtol=1.0e-4)
 
     def test_igrf_dipole_axis(self):
         """Test the IGRF dipole axis calculation"""
-        m = aacgmv2.deprecated.igrf_dipole_axis(self.dtime)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            m = aacgmv2.deprecated.igrf_dipole_axis(self.dtime)
 
         np.testing.assert_allclose(m, [0.050253, -0.160608, 0.985738],
                                    rtol=1.0e-4)

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -6,40 +6,7 @@ import numpy as np
 import pytest
 import aacgmv2
 
-class TestPyAACGMV2:
-
-    @classmethod
-    def test_module_structure(self):
-        """Test module structure"""
-        assert aacgmv2
-        assert aacgmv2.convert_bool_to_bit
-        assert aacgmv2.convert_str_to_bit
-        assert aacgmv2.convert_mlt
-        assert aacgmv2.convert_latlon
-        assert aacgmv2.convert_latlon_arr
-        assert aacgmv2.get_aacgm_coord
-        assert aacgmv2.get_aacgm_coord_arr
-        assert aacgmv2.wrapper
-        assert aacgmv2.wrapper.set_coeff_path
-
-    @classmethod
-    def test_module_parameters(self):
-        """Test module constants"""
-        from os import path
-
-        path1 = path.join("aacgmv2", "aacgmv2", "aacgm_coeffs",
-                          "aacgm_coeffs-12-")
-        if aacgmv2.AACGM_v2_DAT_PREFIX.find(path1) < 0:
-            raise AssertionError()
-
-        path2 = path.join("aacgmv2", "aacgmv2", "magmodel_1590-2015.txt")
-        if aacgmv2.IGRF_COEFFS.find(path2) < 0:
-            raise AssertionError()
-
-        del path1, path2
-
 class TestConvertLatLon:
-
     def setup(self):
         """Runs before every method to create a clean testing setup"""
         self.dtime = dt.datetime(2015, 1, 1, 0, 0, 0)

--- a/aacgmv2/tests/test_struct_aacgmv2.py
+++ b/aacgmv2/tests/test_struct_aacgmv2.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, absolute_import, unicode_literals
+
+import datetime as dt
+import numpy as np
+import pytest
+import aacgmv2
+
+#@pytest.mark.skip(reason="Not meant to be run alone")
+class TestModuleStructure:
+    def setup(self):
+
+        # Define the acceptable output
+        if not hasattr(self, "reference_list"):
+            self.reference_list = list()
+        if not hasattr(self, "module_name"):
+            self.module_name = None
+
+    def teardown(self):
+        del self.reference_list, self.module_name
+
+    def test_module_existence(self):
+        """Test the module existence"""
+
+        # Get the dictionary of functions for the specified module
+        retrieved_dict = aacgmv2.__dict__
+
+        # Submodules only go one level down
+        if self.module_name is None:
+            assert True
+        elif self.module_name != "aacgmv2":
+            assert self.module_name in retrieved_dict.keys()
+        else:
+            assert isinstance(retrieved_dict, dict)
+
+    def test_module_functions(self):
+        """Test module function structure"""
+
+        # Get the dictionary of functions for the specified module
+        retrieved_dict = aacgmv2.__dict__
+
+        if self.module_name is None:
+            assert True
+        else:
+            if self.module_name != "aacgmv2":
+                assert self.module_name in retrieved_dict.keys()
+                retrieved_dict = retrieved_dict[self.module_name].__dict__
+
+            # Get the functions attached to this module and make sure they
+            # are supposed to be there
+            retrieved_list = list()
+            for name in retrieved_dict.keys():
+                if callable(retrieved_dict[name]):
+                    assert name in self.reference_list
+                    retrieved_list.append(name)
+
+            # Test to see if all of the modules match
+            assert len(retrieved_list) == len(self.reference_list)
+
+    def test_modules(self):
+        """Test module submodule structure"""
+        import os
+        import pkgutil
+
+        if self.module_name is None:
+            assert True
+        else:
+            # Get the submodules and make sure they are supposed to be there
+            retrieved_list = list()
+            for imp,name,ispkg in pkgutil.iter_modules(path=aacgmv2.__path__):
+                assert name in self.reference_list
+                retrieved_list.append(name)                
+
+            # Test to see if all of the modules match
+            assert len(retrieved_list) == len(self.reference_list)
+
+class TestDepStructure(TestModuleStructure):
+    def setup(self):
+        self.module_name = None
+        self.reference_list = ["convert", "subsol", "gc2gd_lat",
+                               "igrf_dipole_axis"]
+
+    def teardown(self):
+        del self.module_name, self.reference_list
+
+    def test_dep_existence(self):
+        """ Test the deprecated functions"""
+        self.module_name = "deprecated"
+        self.test_module_existence()
+
+    def test_dep_functions(self):
+        """ Test the deprecated functions"""
+        self.module_name = "deprecated"
+        self.test_module_functions()
+
+class TestCStructure(TestModuleStructure):
+    def setup(self):
+        self.module_name = None
+        self.reference_list = ["set_datetime", "convert", "inv_mlt_convert",
+                               "inv_mlt_convert_yrsec", "mlt_convert",
+                               "mlt_convert_yrsec"]
+
+    def teardown(self):
+        del self.module_name, self.reference_list
+
+    def test_c_existence(self):
+        """ Test the C module existence"""
+        self.module_name = "_aacgmv2"
+        self.test_module_existence()
+
+    def test_c_functions(self):
+        """ Test the C functions"""
+        self.module_name = "_aacgmv2"
+        self.test_module_functions()
+
+
+class TestPyStructure(TestModuleStructure):
+    def setup(self):
+        self.module_name = None
+        self.reference_list = ["convert_bool_to_bit", "convert_str_to_bit",
+                               "convert_mlt", "convert_latlon",
+                               "convert_latlon_arr", "get_aacgm_coord",
+                               "get_aacgm_coord_arr", "set_coeff_path"]
+
+    def teardown(self):
+        del self.module_name, self.reference_list
+
+    def test_py_existence(self):
+        """ Test the python module existence"""
+        self.module_name = "wrapper"
+        self.test_module_existence()
+
+    def test_py_functions(self):
+        """ Test the python functions"""
+        self.module_name = "wrapper"
+        self.test_module_functions()
+
+
+class TestTopStructure(TestModuleStructure):
+    def setup(self):
+        self.module_name = None
+        self.reference_list = list()
+
+    def teardown(self):
+        del self.module_name, self.reference_list
+
+    def test_top_existence(self):
+        """ Test the top level existence"""
+        self.module_name = "aacgmv2"
+        self.test_module_existence()
+
+    def test_top_functions(self):
+        """ Test the deprecated functions"""
+        self.module_name = "aacgmv2"
+        self.reference_list = ["convert_bool_to_bit", "convert_str_to_bit",
+                               "convert_mlt", "convert_latlon",
+                               "convert_latlon_arr", "get_aacgm_coord",
+                               "get_aacgm_coord_arr", "convert"]
+        self.test_module_functions()
+
+    def test_top_modules(self):
+        """ Test the deprecated functions"""
+        self.module_name = "aacgmv2"
+        self.reference_list = ["_aacgmv2", "wrapper",
+                               "deprecated", "__main__"]
+        self.test_modules()
+
+    @classmethod
+    def test_top_parameters(self):
+        """Test module constants"""
+        from os import path
+
+        path1 = path.join("aacgmv2", "aacgmv2", "aacgm_coeffs",
+                          "aacgm_coeffs-12-")
+        if aacgmv2.AACGM_v2_DAT_PREFIX.find(path1) < 0:
+            raise AssertionError()
+
+        path2 = path.join("aacgmv2", "aacgmv2", "magmodel_1590-2015.txt")
+        if aacgmv2.IGRF_COEFFS.find(path2) < 0:
+            raise AssertionError()
+
+        del path1, path2


### PR DESCRIPTION
Added FutureWarning to deprecated functions

# Description

This change uses python Warnings to raise a FutureWarning when any of the routines in deprecated.py are used.  Warnings outputs by default to stderr, and so should not be a problem for people running batch scripts.

Fixes #31 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
import aacgmv2
import datetime as dt

stime = dt.datetime(2017, 1, 20)
glat = 70.0
glon = 0.0
galt = 350.0
aacgmv2.deprecated.convert(glat, glon, galt, date=stime)
```
Output:
> /opt/local/bin/ipython-2.7:1: DeprecationWarning: This routine has been deprecated and may be removed in future versions, recommend using convert_latlon or convert_latlon_arr instead
 > #!/opt/local/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python
> Out[23]: (array([68.90466043]), array([87.19378149]))

**Test Configuration**:
Mac OSX 10.12.6
Python 2.7.15
