### PR TITLE
Very high altitudes with TRACE

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.5.1
+current_version = 2.5.2
 commit = True
 tag = True
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.7"
 sudo: false
 env:
   global:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ Changelog
 * Added FutureWarning to deprecated functions
 * Updated names in licenses
 * Moved module structure routine tests to their own class
+* Added additional exit condition in C tracing routine to avoid hanging
+* Changed version support to 2.7, 3.6, and 3.7
+* Removed logbook dependency
 
 
 2.5.1 (2018-10-19)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 * Added FutureWarning to deprecated functions
 * Updated names in licenses
 * Moved module structure routine tests to their own class
-* Added additional exit condition in C tracing routine to avoid hanging
+* Added high altitude limit to avoid while-loop hanging
 * Changed version support to 2.7, 3.6, and 3.7
 * Removed logbook dependency
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) [2018] Burrell, van der Meeren, Laundal
+Copyright (c) [2019] Burrell, van der Meeren, Laundal
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,7 @@ include CONTRIBUTING.rst
 include LICENSE
 include LICENSE-AstAlg.txt
 include README.rst
+include CODE_OF_CONDUCT.md
 
 include tox.ini .travis.yml appveyor.yml .codeclimate.yml .landscape.yaml
 

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Convert between AACGM and geographic coordinates::
     >>> np.array(aacgmv2.get_aacgm_coord(60, 15, 300, dtime))
     array([57.4698, 93.6300, 1.4822])
     >>> # AACGM to geo, mix arrays/numbers
-    >>> aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, code="A2G")
+    >>> aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G")
     (array([82.9666, -74.3385]), array([-84.6652, 125.8401]), array([14.1244, 12.8771]))
 
 Convert between AACGM and MLT::

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Space Physics, 119, 7501–7521, doi:10.1002/2014JA020264.
 Quick start
 ===========
 
-Install (requires NumPy and logging)::
+Install (requires NumPy)::
 
     pip install aacgmv2
 

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -34,6 +34,7 @@ convert
 convert_mlt
 wrapper.set_coeff_path
 wrapper.test_height
+wrapper.test_time
 deprecated.subsol
 _aacgmv2.convert
 _aacgmv2.set_datetime
@@ -43,9 +44,22 @@ _aacgmv2.inv_mlt_convert
 _aacgmv2.inv_mlt_convert_yrsec
 ---------------------------------------------------------------------------
 """
+# Imports
+#---------------------------------------------------------------------
+
+import logging
 import os as _os
 from sys import stderr
-import logging
+
+from aacgmv2.wrapper import (convert_latlon, convert_mlt, get_aacgm_coord)
+from aacgmv2.wrapper import (convert_latlon_arr, get_aacgm_coord_arr)
+from aacgmv2.wrapper import (convert_bool_to_bit, convert_str_to_bit)
+from aacgmv2 import (deprecated)
+from aacgmv2.deprecated import (convert)
+from aacgmv2 import (_aacgmv2)
+
+# Define global variables
+#---------------------------------------------------------------------
 
 __version__ = "2.5.2"
 
@@ -84,23 +98,3 @@ _os.environ['AACGM_v2_DAT_PREFIX'] = AACGM_v2_DAT_PREFIX
 if __reset_warn__:
     stderr.write("non-default coefficient files may be specified by running " +
                  "aacgmv2.wrapper.set_coeff_path before any other functions\n")
-# Imports
-#---------------------------------------------------------------------
-
-try:
-    from aacgmv2.wrapper import (convert_latlon, convert_mlt, get_aacgm_coord)
-    from aacgmv2.wrapper import (convert_latlon_arr, get_aacgm_coord_arr)
-    from aacgmv2.wrapper import (convert_bool_to_bit, convert_str_to_bit)
-except Exception as err:
-    logger.exception(__file__ + ' -> aacgmv2: ' + str(err))
-
-try:
-    from aacgmv2 import (deprecated)
-    from aacgmv2.deprecated import (convert)
-except Exception as err:
-    logger.exception(__file__ + ' -> aacgmv2: ' + str(err))
-
-try:
-    from aacgmv2 import (_aacgmv2)
-except Exception as err:
-    logger.exception(__file__ + ' -> aacgmv2: ' + str(err))

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -33,6 +33,7 @@ get_aacgm_coord_arr
 convert
 convert_mlt
 wrapper.set_coeff_path
+wrapper.test_height
 deprecated.subsol
 _aacgmv2.convert
 _aacgmv2.set_datetime

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -53,7 +53,7 @@ logger = logging.getLogger('aacgmv2_logger')
 
 # Altitude constraints
 high_alt_coeff = 2000.0 # Tested and published in Shepherd (2014)
-high_alt_trace = 63780.0 # 10 RE, you may have left the magnetosphere!
+high_alt_trace = 6378.0 # 1 RE, these are ionospheric coordinates
 
 # path and filename prefix for the IGRF coefficients
 AACGM_v2_DAT_PREFIX = _os.path.join(_os.path.realpath( \

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -10,6 +10,9 @@ wrapper : Contains current python functions
 
 Parameters
 ---------------------------------------------------------------------------
+logger
+high_alt_coeff
+high_alt_trace
 AACGM_V2_DAT_PREFIX
 IGRF_12_COEFFS
 _aacgmv2.G2A

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -45,6 +45,9 @@ import logging
 
 __version__ = "2.5.2"
 
+# Define a logger object to allow easier log handling
+logger = logging.getLogger('aacgmv2_logger')
+
 # Altitude constraints
 high_alt_coeff = 2000.0 # Tested and published in Shepherd (2014)
 high_alt_trace = 63780.0 # 10 RE, you may have left the magnetosphere!
@@ -81,15 +84,15 @@ try:
     from aacgmv2.wrapper import (convert_latlon_arr, get_aacgm_coord_arr)
     from aacgmv2.wrapper import (convert_bool_to_bit, convert_str_to_bit)
 except Exception as err:
-    logging.exception(__file__ + ' -> aacgmv2: ' + str(err))
+    logger.exception(__file__ + ' -> aacgmv2: ' + str(err))
 
 try:
     from aacgmv2 import (deprecated)
     from aacgmv2.deprecated import (convert)
 except Exception as err:
-    logging.exception(__file__ + ' -> aacgmv2: ' + str(err))
+    logger.exception(__file__ + ' -> aacgmv2: ' + str(err))
 
 try:
     from aacgmv2 import (_aacgmv2)
 except Exception as err:
-    logging.exception(__file__ + ' -> aacgmv2: ' + str(err))
+    logger.exception(__file__ + ' -> aacgmv2: ' + str(err))

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -41,9 +41,9 @@ _aacgmv2.inv_mlt_convert_yrsec
 """
 import os as _os
 from sys import stderr
-import logbook as logging
+import logging
 
-__version__ = "2.5.1"
+__version__ = "2.5.2"
 
 # path and filename prefix for the IGRF coefficients
 AACGM_v2_DAT_PREFIX = _os.path.join(_os.path.realpath( \

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -45,6 +45,10 @@ import logging
 
 __version__ = "2.5.2"
 
+# Altitude constraints
+high_alt_coeff = 2000.0 # Tested and published in Shepherd (2014)
+high_alt_trace = 63780.0 # 10 RE, you may have left the magnetosphere!
+
 # path and filename prefix for the IGRF coefficients
 AACGM_v2_DAT_PREFIX = _os.path.join(_os.path.realpath( \
                                                 _os.path.dirname(__file__)),

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -20,7 +20,6 @@ Laundal, K. M. and A. D. Richmond (2016), Magnetic Coordinate Systems, Space
 
 from __future__ import division, absolute_import, unicode_literals
 import numpy as np
-import logging
 import warnings
 
 def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
@@ -114,14 +113,15 @@ def subsol(year, doy, utime):
     After Fortran code by A. D. Richmond, NCAR. Translated from IDL
     by K. Laundal.
     """
+    import aacgmv2
+
     dstr = "Deprecated routine, may be removed in future versions"
     warnings.warn(dstr, category=FutureWarning)
 
-    
     yr2 = year - 2000
 
     if year >= 2101:
-        logging.error('subsol invalid after 2100. Input year is:', year)
+        aacgmv2.logger.error('subsol invalid after 2100. Input year is:', year)
 
     nleap = np.floor((year - 1601) / 4)
     nleap = nleap - 99

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -15,11 +15,12 @@ References
 Laundal, K. M. and A. D. Richmond (2016), Magnetic Coordinate Systems, Space
  Sci. Rev., doi:10.1007/s11214-016-0275-y.
 -------------------------------------------------------------------------------
+
 """
 
 from __future__ import division, absolute_import, unicode_literals
 import numpy as np
-import logbook as logging
+import logging
 import warnings
 
 def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
@@ -67,7 +68,6 @@ def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
         estr += ' must either use field-line tracing (trace=True '
         estr += 'or allowtrace=True) or indicate you know this is a bad idea'
         estr += ' (badidea=True)'
-        logging.error(estr)
         raise ValueError(estr)
 
     # construct a code from the boolian flags

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -19,8 +19,10 @@ Laundal, K. M. and A. D. Richmond (2016), Magnetic Coordinate Systems, Space
 """
 
 from __future__ import division, absolute_import, unicode_literals
+import datetime as dt
 import numpy as np
 import warnings
+import aacgmv2
 
 def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
             badidea=False, geocentric=False):
@@ -55,9 +57,8 @@ def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
     lon_out : (float)
         Output longitude in degrees E
     """
-    import aacgmv2
 
-    dstr = "Deprecated routine, may be removed in future versions.  Recommend "
+    dstr = "Deprecated routine, will be removed in version 2.6.  Recommend "
     dstr += "using convert_latlon or convert_latlon_arr"
     warnings.warn(dstr, category=FutureWarning)
 
@@ -112,17 +113,19 @@ def subsol(year, doy, utime):
     algorithm).
     After Fortran code by A. D. Richmond, NCAR. Translated from IDL
     by K. Laundal.
+
     """
-    import aacgmv2
 
     dstr = "Deprecated routine, may be removed in future versions"
     warnings.warn(dstr, category=FutureWarning)
 
+    # Convert from 4 digit year to 2 digit year
     yr2 = year - 2000
 
     if year >= 2101:
         aacgmv2.logger.error('subsol invalid after 2100. Input year is:', year)
 
+    # Determine if this year is a leap year
     nleap = np.floor((year - 1601) / 4)
     nleap = nleap - 99
     if year <= 1900:
@@ -132,6 +135,8 @@ def subsol(year, doy, utime):
         ncent = 3 - ncent
         nleap = nleap + ncent
 
+    # Calculate some of the coefficients needed to deterimine the mean longitude
+    # of the sun and the mean anomaly
     l_0 = -79.549 + (-0.238699 * (yr2 - 4 * nleap) + 3.08514e-2 * nleap)
     g_0 = -2.472 + (-0.2558905 * (yr2 - 4 * nleap) - 3.79617e-2 * nleap)
 
@@ -214,8 +219,6 @@ def igrf_dipole_axis(date):
     work after IGRF updates.  The dipole coefficients are interpolated to the
     date, or extrapolated if date > latest IGRF model
     """
-    import datetime as dt
-    import aacgmv2
 
     dstr = "Deprecated routine, may be removed in future versions"
     warnings.warn(dstr, category=FutureWarning)

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -78,7 +78,7 @@ def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
 
     # convert location
     lat_out, lon_out, _ = aacgmv2.convert_latlon_arr(lat, lon, alt, date,
-                                                     code=bit_code)
+                                                     method_code=bit_code)
 
     return lat_out, lon_out
 

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import division, absolute_import, unicode_literals
 
+import datetime as dt
 import numpy as np
 import pytest
 import aacgmv2
@@ -252,7 +253,6 @@ class TestCAACGMV2:
 
     def test_inv_mlt_convert_yrsec(self):
         """Test MLT inversion with year and seconds of year"""
-        import datetime as dt
         dtime = dt.datetime(*self.long_date)
         soy = (int(dtime.strftime("%j"))-1) * 86400 + dtime.hour * 3600 + \
               dtime.minute * 60 + dtime.second
@@ -291,7 +291,6 @@ class TestCAACGMV2:
 
     def test_mlt_convert_yrsec(self):
         """Test MLT calculation using year and seconds of year"""
-        import datetime as dt
         dtime = dt.datetime(*self.long_date)
         soy = (int(dtime.strftime("%j"))-1) * 86400 + dtime.hour * 3600 + \
             dtime.minute * 60 + dtime.second

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -145,6 +145,43 @@ class TestCAACGMV2:
 
         del code
 
+    def test_convert_very_high_TRACE_failure(self):
+        """Test failure with very high altitude geodetic to magnetic coordinates
+        using trace"""
+        self.date_args[0] = (2001, 1, 1, 2, 26, 0)
+        self.lat_in[0] = 44.757
+        self.lon_in[0] = 286.893
+        self.alt_in[0] = 6371000000.2
+        
+        code = aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE
+        aacgmv2._aacgmv2.set_datetime(*self.date_args[0])
+        
+        with pytest.raises(RuntimeError):
+            aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0],
+                                     self.alt_in[0], code)
+
+        del code
+
+    def test_convert_very_high_TRACE_success(self):
+        """Test success with very high altitude geodetic to magnetic coordinates
+        using trace"""
+        self.date_args[0] = (2001, 1, 1, 2, 26, 0)
+        self.lat_in[0] = 0.0
+        self.lon_in[0] = 180.0
+        self.alt_in[0] = 1000000000000000000.
+        
+        code = aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE
+        aacgmv2._aacgmv2.set_datetime(*self.date_args[0])
+        (self.mlat, self.mlon,
+         self.rshell) = aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0],
+                                                 self.alt_in[0], code)
+        np.testing.assert_almost_equal(self.mlat, -90.0, decimal=4)
+        np.testing.assert_almost_equal(self.mlon, -108.0994, decimal=4)
+        np.testing.assert_almost_equal(self.rshell, 1.5695630336514416*1.0e14,
+                                       decimal=4)
+
+        del code
+
     def test_convert_high_ALLOWTRACE(self):
         """Test convert from high altitude geodetic to magnetic coordinates
         by allowing IGRF tracing"""

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -145,43 +145,6 @@ class TestCAACGMV2:
 
         del code
 
-    def test_convert_very_high_TRACE_failure(self):
-        """Test failure with very high altitude geodetic to magnetic coordinates
-        using trace"""
-        self.date_args[0] = (2001, 1, 1, 2, 26, 0)
-        self.lat_in[0] = 44.757
-        self.lon_in[0] = 286.893
-        self.alt_in[0] = 6371000000.2
-        
-        code = aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE
-        aacgmv2._aacgmv2.set_datetime(*self.date_args[0])
-        
-        with pytest.raises(RuntimeError):
-            aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0],
-                                     self.alt_in[0], code)
-
-        del code
-
-    def test_convert_very_high_TRACE_success(self):
-        """Test success with very high altitude geodetic to magnetic coordinates
-        using trace"""
-        self.date_args[0] = (2001, 1, 1, 2, 26, 0)
-        self.lat_in[0] = 0.0
-        self.lon_in[0] = 180.0
-        self.alt_in[0] = 1000000000000000000.
-        
-        code = aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE
-        aacgmv2._aacgmv2.set_datetime(*self.date_args[0])
-        (self.mlat, self.mlon,
-         self.rshell) = aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0],
-                                                 self.alt_in[0], code)
-        np.testing.assert_almost_equal(self.mlat, -90.0, decimal=4)
-        np.testing.assert_almost_equal(self.mlon, -108.0994, decimal=4)
-        np.testing.assert_almost_equal(self.rshell, 1.5695630336514416*1.0e14,
-                                       decimal=4)
-
-        del code
-
     def test_convert_high_ALLOWTRACE(self):
         """Test convert from high altitude geodetic to magnetic coordinates
         by allowing IGRF tracing"""

--- a/aacgmv2/tests/test_cmd_aacgmv2.py
+++ b/aacgmv2/tests/test_cmd_aacgmv2.py
@@ -3,6 +3,7 @@ from __future__ import division, absolute_import, unicode_literals
 
 import subprocess
 import numpy as np
+import os
 
 class testCmdAACGMV2:
     def setup(self):
@@ -15,8 +16,6 @@ class testCmdAACGMV2:
 
     def teardown(self):
         """Runs after every method to clean up previous testing"""
-        import os
-
         if os.path.isfile(self.output):
             os.remove(self.output)
 

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -2,11 +2,13 @@
 from __future__ import division, absolute_import, unicode_literals
 
 import datetime as dt
+from io import StringIO
+import logging
 import numpy as np
 import pytest
-import aacgmv2
 import warnings
-import logging
+
+import aacgmv2
 
 class TestFutureDepWarning:
     def setup(self):
@@ -80,7 +82,6 @@ class TestDepAACGMV2Warning(TestFutureDepWarning):
 class TestDepLogging:
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        from io import StringIO
 
         self.log_capture = StringIO()
         aacgmv2.logger.addHandler(logging.StreamHandler(self.log_capture))

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -99,7 +99,6 @@ class TestDepLogging:
 
         aacgmv2.convert(*self.in_convert)
         self.lout = self.log_capture.getvalue()
-        print self.lout
         assert self.lout.find(self.lwarn) >= 0
 
 

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -255,7 +255,7 @@ class TestDepAACGMV2:
 
     def test_convert_time_failure(self):
         """Test conversion with a bad time"""
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 self.lat, self.lon = aacgmv2.convert([60], [0], [300], None)
@@ -279,7 +279,7 @@ class TestDepAACGMV2:
 
     def test_convert_lat_failure(self):
         """Test error return for co-latitudes above 90 for an array"""
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 aacgmv2.convert([91, 60, -91], 0, 300, self.dtime)

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 import aacgmv2
 import warnings
+import logging
 
 class TestFutureDepWarning:
     def setup(self):
@@ -74,7 +75,34 @@ class TestDepAACGMV2Warning(TestFutureDepWarning):
         self.test_routine = aacgmv2.deprecated.igrf_dipole_axis
         self.test_args = [self.dtime]
         self.test_future_dep_warning()
-        
+
+
+class TestDepLogging:
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        from io import StringIO
+
+        self.log_capture = StringIO()
+        aacgmv2.logger.addHandler(logging.StreamHandler(self.log_capture))
+
+        self.in_convert = ([60], [0], [-1], dt.datetime(2015, 1, 1, 0, 0, 0))
+        self.lwarn = u"conversion not intended for altitudes < 0 km"
+        self.lout = ''
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+        self.log_capture.close()
+        del self.in_convert, self.lwarn, self.lout
+
+    def test_warning_below_ground_convert(self):
+        """ Test that a warning is issued if altitude is below zero"""
+
+        aacgmv2.convert(*self.in_convert)
+        self.lout = self.log_capture.getvalue()
+        print self.lout
+        assert self.lout.find(self.lwarn) >= 0
+
+
 class TestDepAACGMV2:
     def setup(self):
         """Runs before every method to create a clean testing setup"""
@@ -240,20 +268,6 @@ class TestDepAACGMV2:
 
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
-
-    def test_warning_below_ground_convert(self):
-        """ Test that a warning is issued if altitude is below zero"""
-        import logbook
-        lwarn = u"conversion not intended for altitudes < 0 km"
-
-        with logbook.TestHandler() as handler:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                self.lat, self.lon = aacgmv2.convert([60], [0], [-1],
-                                                     self.dtime)
-                assert handler.has_warning(lwarn)
-
-        handler.close()
 
     def test_convert_maxalt_failure(self):
         """For an array, test failure for an altitude too high for

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -2,10 +2,13 @@
 from __future__ import division, absolute_import, unicode_literals
 
 import datetime as dt
-import numpy as np
-import pytest
-import aacgmv2
+from io import StringIO
 import logging
+import numpy as np
+import os
+import pytest
+
+import aacgmv2
 
 class TestConvertLatLon:
     def setup(self):
@@ -1008,7 +1011,6 @@ class TestCoeffPath:
 
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        import os
         os.environ['IGRF_COEFFS'] = "default_igrf"
         os.environ['AACGM_v2_DAT_PREFIX'] = "default_coeff"
         self.default_igrf = os.environ['IGRF_COEFFS']
@@ -1020,7 +1022,6 @@ class TestCoeffPath:
 
     def test_set_coeff_path_default(self):
         """Test the coefficient path setting using default values"""
-        import os
         aacgmv2.wrapper.set_coeff_path()
 
         if os.environ['IGRF_COEFFS'] != self.default_igrf:
@@ -1031,7 +1032,6 @@ class TestCoeffPath:
     @classmethod
     def test_set_coeff_path_string(self):
         """Test the coefficient path setting using two user specified values"""
-        import os
         aacgmv2.wrapper.set_coeff_path("hi", "bye")
 
         if os.environ['IGRF_COEFFS'] != "hi":
@@ -1042,7 +1042,6 @@ class TestCoeffPath:
     @classmethod
     def test_set_coeff_path_true(self):
         """Test the coefficient path setting using the module values"""
-        import os
         aacgmv2.wrapper.set_coeff_path(True, True)
 
         if os.environ['IGRF_COEFFS'] != aacgmv2.IGRF_COEFFS:
@@ -1052,7 +1051,6 @@ class TestCoeffPath:
 
     def test_set_only_aacgm_coeff_path(self):
         """Test the coefficient path setting using a mix of input"""
-        import os
         aacgmv2.wrapper.set_coeff_path(coeff_prefix="hi")
 
         if os.environ['IGRF_COEFFS'] != self.default_igrf:
@@ -1062,7 +1060,6 @@ class TestCoeffPath:
 
     def test_set_only_igrf_coeff_path(self):
         """Test the coefficient path setting using a mix of input"""
-        import os
         aacgmv2.wrapper.set_coeff_path(igrf_file="hi")
 
         if os.environ['IGRF_COEFFS'] != "hi":
@@ -1073,7 +1070,6 @@ class TestCoeffPath:
     @classmethod
     def test_set_both_mixed(self):
         """Test the coefficient path setting using a mix of input"""
-        import os
         aacgmv2.wrapper.set_coeff_path(igrf_file=True, coeff_prefix="hi")
 
         if os.environ['IGRF_COEFFS'] != aacgmv2.IGRF_COEFFS:
@@ -1133,7 +1129,6 @@ class TestHeightReturns:
 class TestPyLogging:
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        from io import StringIO
 
         self.lwarn = u""
         self.lout = u""
@@ -1181,3 +1176,34 @@ class TestPyLogging:
         self.lout = self.log_capture.getvalue()
         if self.lout.find(self.lwarn) < 0:
             raise AssertionError()
+
+class TestTimeReturns:
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        self.dtime = dt.datetime(2015, 1, 1, 0, 0, 0)
+        self.dtime2 = dt.datetime(2015, 1, 1, 10, 10, 10)
+        self.ddate = dt.date(2015, 1, 1)
+        
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+        del self.dtime, self.ddate, self.dtime2
+
+    def test_good_time(self):
+        """ Test to see that a good datetime is accepted"""
+
+        assert self.dtime == aacgmv2.wrapper.test_time(self.dtime)
+
+    def test_good_time_with_nonzero_time(self):
+        """ Test to see that a good datetime with h/m/s is accepted"""
+
+        assert self.dtime2 == aacgmv2.wrapper.test_time(self.dtime2)
+
+    def test_good_date(self):
+        """ Test to see that a good date has a good datetime output"""
+
+        assert self.dtime == aacgmv2.wrapper.test_time(self.dtime)
+
+    def test_bad_time(self):
+        """ Test to see that a warning is raised with a bad time input"""
+        with pytest.raises(ValueError):
+            aacgmv2.wrapper.test_time(2015)

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -89,6 +89,17 @@ class TestConvertLatLon:
                 np.isnan(self.r_out)):
             raise AssertionError()
 
+    def test_convert_latlon_veryhigh_failure(self):
+        """For a single value, test failure for a very high altitude with trace
+        """
+        (self.lat_out, self.lon_out,
+         self.r_out) = aacgmv2.convert_latlon(44.757, 286.893, 6371000000.2,
+                                              dt.datetime(2001,1,1,2,26),
+                                              code='G2A|TRACE')
+        if not (np.isnan(self.lat_out) & np.isnan(self.lon_out) &
+                np.isnan(self.r_out)):
+            raise AssertionError()
+
     def test_convert_latlon_lat_failure(self):
         """Test error return for co-latitudes above 90 for a single value"""
         with pytest.raises(AssertionError):
@@ -443,6 +454,15 @@ class TestGetAACGMCoord:
         np.testing.assert_almost_equal(self.mlon_out, 83.3027, decimal=4)
         np.testing.assert_almost_equal(self.mlt_out, 0.3307, decimal=4)
         del method
+
+    def test_get_aacgm_coord_veryhigh_failure(self):
+        """Test single value AACGMV2 calculation with a very high altitude"""
+        (self.mlat_out, self.mlon_out,
+         self.mlt_out) = aacgmv2.get_aacgm_coord(44.757, 286.893, 6371000000.2,
+                                                 dt.datetime(2001, 1, 1, 2, 26))
+        if not (np.isnan(self.mlat_out) & np.isnan(self.mlon_out) &
+                np.isnan(self.mlt_out)):
+            raise AssertionError()
 
     def test_get_aacgm_coord_location_failure(self):
         """Test single value AACGMV2 calculation with a bad location"""

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -89,17 +89,6 @@ class TestConvertLatLon:
                 np.isnan(self.r_out)):
             raise AssertionError()
 
-    def test_convert_latlon_veryhigh_failure(self):
-        """For a single value, test failure for a very high altitude with trace
-        """
-        (self.lat_out, self.lon_out,
-         self.r_out) = aacgmv2.convert_latlon(44.757, 286.893, 6371000000.2,
-                                              dt.datetime(2001,1,1,2,26),
-                                              code='G2A|TRACE')
-        if not (np.isnan(self.lat_out) & np.isnan(self.lon_out) &
-                np.isnan(self.r_out)):
-            raise AssertionError()
-
     def test_convert_latlon_lat_failure(self):
         """Test error return for co-latitudes above 90 for a single value"""
         with pytest.raises(AssertionError):
@@ -454,15 +443,6 @@ class TestGetAACGMCoord:
         np.testing.assert_almost_equal(self.mlon_out, 83.3027, decimal=4)
         np.testing.assert_almost_equal(self.mlt_out, 0.3307, decimal=4)
         del method
-
-    def test_get_aacgm_coord_veryhigh_failure(self):
-        """Test single value AACGMV2 calculation with a very high altitude"""
-        (self.mlat_out, self.mlon_out,
-         self.mlt_out) = aacgmv2.get_aacgm_coord(44.757, 286.893, 6371000000.2,
-                                                 dt.datetime(2001, 1, 1, 2, 26))
-        if not (np.isnan(self.mlat_out) & np.isnan(self.mlon_out) &
-                np.isnan(self.mlt_out)):
-            raise AssertionError()
 
     def test_get_aacgm_coord_location_failure(self):
         """Test single value AACGMV2 calculation with a bad location"""

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -39,6 +39,17 @@ class TestConvertLatLon:
 
         del code
 
+    def test_convert_latlon_trace_badidea(self):
+        """Test single value latlon conversion with a bad flag for trace"""
+        code = "G2A | TRACE | BADIDEA"
+        (self.lat_out, self.lon_out,
+         self.r_out) = aacgmv2.convert_latlon(60, 0, 7000, self.dtime, code)
+        np.testing.assert_almost_equal(self.lat_out, 69.3174, decimal=4)
+        np.testing.assert_almost_equal(self.lon_out, 85.0995, decimal=4)
+        np.testing.assert_almost_equal(self.r_out, 2.0973, decimal=4)
+
+        del code
+
     def test_convert_latlon_location_failure(self):
         """Test single value latlon conversion with a bad location"""
         (self.lat_out, self.lon_out,
@@ -331,6 +342,17 @@ class TestConvertLatLonArr:
         np.testing.assert_allclose(self.lat_out, [64.35677791], rtol=1e-4)
         np.testing.assert_allclose(self.lon_out, [83.30272053], rtol=1e-4)
         np.testing.assert_allclose(self.r_out, [1.46944431], rtol=1e-4)
+
+    def test_convert_latlon_arr_badidea_trace(self):
+        """Test array latlon conversion for BADIDEA with trace"""
+        code = "G2A | BADIDEA | TRACE"
+        (self.lat_out, self.lon_out,
+         self.r_out) = aacgmv2.convert_latlon_arr([60], [0], [7000],
+                                                  self.dtime, code)
+
+        np.testing.assert_allclose(self.lat_out, [69.317391], rtol=1e-4)
+        np.testing.assert_allclose(self.lon_out, [85.099499], rtol=1e-4)
+        np.testing.assert_allclose(self.r_out, [2.09726], rtol=1e-4)
 
     def test_convert_latlon_arr_location_failure(self):
         """Test array latlon conversion with a bad location"""
@@ -1108,6 +1130,78 @@ class TestPyLogging:
         self.lwarn = u"conversion not intended for altitudes < 0 km"
 
         aacgmv2.get_aacgm_coord(60, 0, -1, self.dtime)
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_magnetosphere_get_aacgm_coord_arr(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"coordinates are not intended for the magnetosphere"
+
+        aacgmv2.get_aacgm_coord_arr([90], [60], [7000], self.dtime, 'G2A|TRACE')
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_magnetosphere_convert_latlon(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"coordinates are not intended for the magnetosphere"
+
+        aacgmv2.convert_latlon(60, 0, 7000, self.dtime, 'G2A|TRACE')
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_magnetosphere_convert_latlon_arr(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"coordinates are not intended for the magnetosphere"
+
+        aacgmv2.convert_latlon_arr([60], [0], [7000], self.dtime, 'G2A|TRACE')
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_magnetosphere_get_aacgm_coord(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"coordinates are not intended for the magnetosphere"
+
+        aacgmv2.get_aacgm_coord(60, 0, 7000, self.dtime, 'G2A|TRACE')
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_high_coeff_alt_get_aacgm_coord_arr(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"must either use field-line tracing (trace=True"
+
+        aacgmv2.get_aacgm_coord_arr([90], [60], [3000], self.dtime, 'G2A')
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_high_coeff_alt_convert_latlon(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"must either use field-line tracing (trace=True"
+
+        aacgmv2.convert_latlon(60, 0, 3000, self.dtime, 'G2A')
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_high_coeff_alt_convert_latlon_arr(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"must either use field-line tracing (trace=True"
+
+        aacgmv2.convert_latlon_arr([60], [0], [3000], self.dtime, 'G2A')
+        self.lout = self.log_capture.getvalue()
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError()
+
+    def test_warning_high_coeff_alt_get_aacgm_coord(self):
+        """ Test that a warning is issued if altitude is very high"""
+        self.lwarn = u"must either use field-line tracing (trace=True"
+
+        aacgmv2.get_aacgm_coord(60, 0, 3000, self.dtime, 'G2A')
         self.lout = self.log_capture.getvalue()
         if self.lout.find(self.lwarn) < 0:
             raise AssertionError()

--- a/aacgmv2/tests/test_struct_aacgmv2.py
+++ b/aacgmv2/tests/test_struct_aacgmv2.py
@@ -122,7 +122,8 @@ class TestPyStructure(TestModuleStructure):
         self.reference_list = ["convert_bool_to_bit", "convert_str_to_bit",
                                "convert_mlt", "convert_latlon", "test_height",
                                "convert_latlon_arr", "get_aacgm_coord",
-                               "get_aacgm_coord_arr", "set_coeff_path"]
+                               "get_aacgm_coord_arr", "set_coeff_path",
+                               "test_time"]
 
     def teardown(self):
         del self.module_name, self.reference_list

--- a/aacgmv2/tests/test_struct_aacgmv2.py
+++ b/aacgmv2/tests/test_struct_aacgmv2.py
@@ -2,8 +2,12 @@
 from __future__ import division, absolute_import, unicode_literals
 
 import datetime as dt
+import logging
 import numpy as np
+import os
+import pkgutil
 import pytest
+
 import aacgmv2
 
 #@pytest.mark.skip(reason="Not meant to be run alone")
@@ -59,8 +63,6 @@ class TestModuleStructure:
 
     def test_modules(self):
         """Test module submodule structure"""
-        import os
-        import pkgutil
 
         if self.module_name is None:
             assert True
@@ -168,14 +170,13 @@ class TestTopStructure(TestModuleStructure):
     @classmethod
     def test_top_parameters(self):
         """Test module constants"""
-        from os import path
 
-        path1 = path.join("aacgmv2", "aacgmv2", "aacgm_coeffs",
+        path1 = os.path.join("aacgmv2", "aacgmv2", "aacgm_coeffs",
                           "aacgm_coeffs-12-")
         if aacgmv2.AACGM_v2_DAT_PREFIX.find(path1) < 0:
             raise AssertionError()
 
-        path2 = path.join("aacgmv2", "aacgmv2", "magmodel_1590-2015.txt")
+        path2 = os.path.join("aacgmv2", "aacgmv2", "magmodel_1590-2015.txt")
         if aacgmv2.IGRF_COEFFS.find(path2) < 0:
             raise AssertionError()
 
@@ -200,7 +201,6 @@ class TestTopStructure(TestModuleStructure):
     @classmethod
     def test_module_logger(self):
         """ Test the module logger instance"""
-        import logging
         
         if not isinstance(aacgmv2.logger, logging.Logger):
             raise TypeError("Logger incorrect type")

--- a/aacgmv2/tests/test_struct_aacgmv2.py
+++ b/aacgmv2/tests/test_struct_aacgmv2.py
@@ -180,3 +180,27 @@ class TestTopStructure(TestModuleStructure):
             raise AssertionError()
 
         del path1, path2
+
+    @classmethod
+    def test_high_alt_variables(self):
+        """ Test that module altitude limits exist and are appropriate"""
+
+        if not isinstance(aacgmv2.high_alt_coeff, float):
+            raise TypeError("Coefficient upper limit not float")
+
+        if not isinstance(aacgmv2.high_alt_trace, float):
+            raise TypeError("Trace upper limit not float")
+
+        if aacgmv2.high_alt_coeff != 2000.0:
+            raise ValueError("unexpected coefficient upper limit")
+
+        if aacgmv2.high_alt_trace <= aacgmv2.high_alt_trace:
+            raise ValueError("Trace limit lower than coefficient limit")
+
+    @classmethod
+    def test_module_logger(self):
+        """ Test the module logger instance"""
+        import logging
+        
+        if not isinstance(aacgmv2.logger, logging.Logger):
+            raise TypeError("Logger incorrect type")

--- a/aacgmv2/tests/test_struct_aacgmv2.py
+++ b/aacgmv2/tests/test_struct_aacgmv2.py
@@ -118,7 +118,7 @@ class TestPyStructure(TestModuleStructure):
     def setup(self):
         self.module_name = None
         self.reference_list = ["convert_bool_to_bit", "convert_str_to_bit",
-                               "convert_mlt", "convert_latlon",
+                               "convert_mlt", "convert_latlon", "test_height",
                                "convert_latlon_arr", "get_aacgm_coord",
                                "get_aacgm_coord_arr", "set_coeff_path"]
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -12,12 +12,13 @@ convert_str_to_bit : Convert human readible AACGM flag to bits
 convert_bool_to_bit : Convert boolian flags to bits
 convert_mlt : Get array mlt
 --------------
+
 """
 
 from __future__ import division, absolute_import, unicode_literals
 import datetime as dt
 import numpy as np
-import logbook as logging
+import logging
 
 # Setting a sensible high altitude limit to 10 Re, should probably be lower (km)
 high_alt = 63780.0

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -18,7 +18,6 @@ convert_mlt : Get array mlt
 from __future__ import division, absolute_import, unicode_literals
 import datetime as dt
 import numpy as np
-import logging
 
 def set_coeff_path(igrf_file=False, coeff_prefix=False):
     """Sets the IGRF_COEFF and AACGMV_V2_DAT_PREFIX environment variables.
@@ -112,7 +111,7 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
 
     # Test height
     if height < 0:
-        logging.warn('conversion not intended for altitudes < 0 km')
+        aacgmv2.logger.warn('conversion not intended for altitudes < 0 km')
 
     # Initialise output
     lat_out = np.nan
@@ -130,13 +129,13 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
                             'must either use field-line tracing (trace=True or',
                             ' allowtrace=True) or indicate you know this is a',
                             ' bad idea'])
-            logging.error(estr)
+            aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
 
         if height > aacgmv2.high_alt_trace:
             estr = ''.join(['tracing not intended for great heights! Limit at ',
                             '{:.0f} km'.format(aacgmv2.high_alt_trace)])
-            logging.error(estr)
+            aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
 
         # make flag
@@ -222,8 +221,8 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
                            len(height.shape)])
     if test_array.min() == 0:
         if test_array.max() == 0:
-            logging.warn("for a single location, consider using " \
-                         "convert_latlon or get_aacgm_coord")
+            aacgmv2.logger.warn("for a single location, consider using " \
+                                "convert_latlon or get_aacgm_coord")
             in_lat = np.array([in_lat])
             in_lon = np.array([in_lon])
             height = np.array([height])
@@ -240,7 +239,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
     if not (in_lat.shape == in_lon.shape and in_lat.shape == height.shape):
         ulen = np.unique([in_lat.shape, in_lon.shape, height.shape])
         if ulen.min() != (1,):
-            logging.error("mismatched input arrays")
+            aacgmv2.logger.error("mismatched input arrays")
             return None, None, None
 
     # Test time
@@ -252,7 +251,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
 
     # Test height
     if np.min(height) < 0:
-        logging.warn('conversion not intended for altitudes < 0 km')
+        aacgmv2.logger.warn('conversion not intended for altitudes < 0 km')
 
     # Initialise output
     lat_out = np.full(shape=in_lat.shape, fill_value=np.nan)
@@ -270,13 +269,13 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
                             'must either use field-line tracing (trace=True or',
                             ' allowtrace=True) or indicate you know this is a ',
                             'bad idea'])
-            logging.error(estr)
+            aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
         
         if np.nanmax(height) > aacgmv2.high_alt_trace:
             estr = ''.join(['tracing not intended for great heights! Limit at ',
                             '{:.0f} km'.format(aacgmv2.high_alt_trace)])
-            logging.error(estr)
+            aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
 
         # make flag

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -227,20 +227,22 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
             in_lon = np.array([in_lon])
             height = np.array([height])
         else:
+            imax = test_array.argmax()
+            max_shape = in_lat.shape if imax == 0 else (in_lon.shape \
+                                            if imax == 1 else height.shape) 
             if test_array[0] == 0:
-                in_lat = np.full(shape=test_array.max(), fill_value=in_lat)
+                in_lat = np.full(shape=max_shape, fill_value=in_lat)
             if not test_array[1]:
-                in_lon = np.full(shape=test_array.max(), fill_value=in_lon)
+                in_lon = np.full(shape=max_shape, fill_value=in_lon)
             if not test_array[2]:
-                height = np.full(shape=test_array.max(), fill_value=height)
+                height = np.full(shape=max_shape, fill_value=height)
 
     # Ensure that lat, lon, and height are the same length or if the lengths
     # differ that the different ones contain only a single value
     if not (in_lat.shape == in_lon.shape and in_lat.shape == height.shape):
         ulen = np.unique([in_lat.shape, in_lon.shape, height.shape])
         if ulen.min() != (1,):
-            aacgmv2.logger.error("mismatched input arrays")
-            return None, None, None
+            raise ValueError('mismatched input arrays')
 
     # Test time
     if isinstance(dtime, dt.date):

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -132,9 +132,12 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
             aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
 
-        if height > aacgmv2.high_alt_trace:
-            estr = ''.join(['tracing not intended for great heights! Limit at ',
-                            '{:.0f} km'.format(aacgmv2.high_alt_trace)])
+        if height > aacgmv2.high_alt_trace and code.find("BADIDEA") < 0:
+            estr = ''.join(['these coordinates are not intended for the ',
+                            'magnetosphere! You must indicate that you know ',
+                            'this is a bad idea.  If you continue, it is ',
+                            'possible that the code will hang.'])
+
             aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
 
@@ -274,9 +277,12 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
             aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
         
-        if np.nanmax(height) > aacgmv2.high_alt_trace:
-            estr = ''.join(['tracing not intended for great heights! Limit at ',
-                            '{:.0f} km'.format(aacgmv2.high_alt_trace)])
+        if(np.nanmax(height) > aacgmv2.high_alt_trace and
+           code.find("BADIDEA") < 0):
+            estr = ''.join(['these coordinates are not intended for the ',
+                            'magnetosphere! You must indicate that you know ',
+                            'this is a bad idea.  If you continue, it is ',
+                            'possible that the code will hang.'])
             aacgmv2.logger.error(estr)
             return lat_out, lon_out, r_out
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -111,7 +111,7 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
 
     # Test height
     if height < 0:
-        aacgmv2.logger.warn('conversion not intended for altitudes < 0 km')
+        aacgmv2.logger.warning('conversion not intended for altitudes < 0 km')
 
     # Initialise output
     lat_out = np.nan
@@ -221,8 +221,8 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
                            len(height.shape)])
     if test_array.min() == 0:
         if test_array.max() == 0:
-            aacgmv2.logger.warn("for a single location, consider using " \
-                                "convert_latlon or get_aacgm_coord")
+            aacgmv2.logger.warning("for a single location, consider using " \
+                                   "convert_latlon or get_aacgm_coord")
             in_lat = np.array([in_lat])
             in_lon = np.array([in_lon])
             height = np.array([height])
@@ -253,7 +253,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
 
     # Test height
     if np.min(height) < 0:
-        aacgmv2.logger.warn('conversion not intended for altitudes < 0 km')
+        aacgmv2.logger.warning('conversion not intended for altitudes < 0 km')
 
     # Initialise output
     lat_out = np.full(shape=in_lat.shape, fill_value=np.nan)

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -19,6 +19,11 @@ import datetime as dt
 import numpy as np
 import logbook as logging
 
+# Setting a sensible high altitude limit to 10 Re, should probably be lower (km)
+high_alt = 63780.0
+# High altitude limit for coefficients (km)
+high_coeff_alt = 2000
+
 def set_coeff_path(igrf_file=False, coeff_prefix=False):
     """Sets the IGRF_COEFF and AACGMV_V2_DAT_PREFIX environment variables.
 
@@ -121,7 +126,7 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
     try:
         code = code.upper()
 
-        if(height > 2000 and code.find("TRACE") < 0 and
+        if(height > high_alt_coeff and code.find("TRACE") < 0 and
            code.find("ALLOWTRACE") < 0 and code.find("BADIDEA") < 0):
             estr = 'coefficients are not valid for altitudes above 2000 km. You'
             estr += ' must either use field-line tracing (trace=True '
@@ -130,6 +135,12 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
             logging.error(estr)
             return lat_out, lon_out, r_out
 
+        if height > high_alt:
+            estr = 'Coordinates not intended for magnetospheric altitudes!'
+            logging.error(estr)
+            return lat_out, lon_out, r_out
+            
+        
         # make flag
         bit_code = convert_str_to_bit(code)
     except AttributeError:
@@ -253,7 +264,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
     try:
         code = code.upper()
 
-        if(np.nanmax(height) > 2000 and code.find("TRACE") < 0 and
+        if(np.nanmax(height) > high_alt_coeff and code.find("TRACE") < 0 and
            code.find("ALLOWTRACE") < 0 and code.find("BADIDEA") < 0):
             estr = 'coefficients are not valid for altitudes above 2000 km. You'
             estr += ' must either use field-line tracing (trace=True '
@@ -294,6 +305,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
     try:
         lat_out, lon_out, r_out = convert_vectorised(in_lat, in_lon, height,
                                                      bit_code)
+
     except:
         pass
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -134,11 +134,11 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
             return lat_out, lon_out, r_out
 
         if height > aacgmv2.high_alt_trace:
-            estr = 'Coordinates not intended for magnetospheric altitudes!'
+            estr = ''.join(['tracing not intended for great heights! Limit at ',
+                            '{:.0f} km'.format(aacgmv2.high_alt_trace)])
             logging.error(estr)
             return lat_out, lon_out, r_out
-            
-        
+
         # make flag
         bit_code = convert_str_to_bit(code)
     except AttributeError:
@@ -270,6 +270,12 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
                             'must either use field-line tracing (trace=True or',
                             ' allowtrace=True) or indicate you know this is a ',
                             'bad idea'])
+            logging.error(estr)
+            return lat_out, lon_out, r_out
+        
+        if np.nanmax(height) > aacgmv2.high_alt_trace:
+            estr = ''.join(['tracing not intended for great heights! Limit at ',
+                            '{:.0f} km'.format(aacgmv2.high_alt_trace)])
             logging.error(estr)
             return lat_out, lon_out, r_out
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -20,11 +20,6 @@ import datetime as dt
 import numpy as np
 import logging
 
-# Setting a sensible high altitude limit to 10 Re, should probably be lower (km)
-high_alt = 63780.0
-# High altitude limit for coefficients (km)
-high_coeff_alt = 2000
-
 def set_coeff_path(igrf_file=False, coeff_prefix=False):
     """Sets the IGRF_COEFF and AACGMV_V2_DAT_PREFIX environment variables.
 
@@ -127,16 +122,17 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
     try:
         code = code.upper()
 
-        if(height > high_alt_coeff and code.find("TRACE") < 0 and
+        if(height > aacgmv2.high_alt_coeff and code.find("TRACE") < 0 and
            code.find("ALLOWTRACE") < 0 and code.find("BADIDEA") < 0):
-            estr = 'coefficients are not valid for altitudes above 2000 km. You'
-            estr += ' must either use field-line tracing (trace=True '
-            estr += 'or allowtrace=True) or indicate you know this '
-            estr += 'is a bad idea'
+            estr = ''.join(['coefficients are not valid for altitudes above ',
+                            '{:.0f} km. You '.format(aacgmv2.high_alt_coeff),
+                            'must either use field-line tracing (trace=True '
+                            'or allowtrace=True) or indicate you know this '
+                            'is a bad idea'])
             logging.error(estr)
             return lat_out, lon_out, r_out
 
-        if height > high_alt:
+        if height > aacgmv2.high_alt_trace:
             estr = 'Coordinates not intended for magnetospheric altitudes!'
             logging.error(estr)
             return lat_out, lon_out, r_out
@@ -265,12 +261,13 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
     try:
         code = code.upper()
 
-        if(np.nanmax(height) > high_alt_coeff and code.find("TRACE") < 0 and
-           code.find("ALLOWTRACE") < 0 and code.find("BADIDEA") < 0):
-            estr = 'coefficients are not valid for altitudes above 2000 km. You'
-            estr += ' must either use field-line tracing (trace=True '
-            estr += 'or allowtrace=True) or indicate you know this '
-            estr += 'is a bad idea'
+        if(np.nanmax(height) > aacgmv2.high_alt_coeff and code.find("TRACE") < 0
+           and code.find("ALLOWTRACE") < 0 and code.find("BADIDEA") < 0):
+            estr = ''.join(['coefficients are not valid for altitudes above ',
+                            '{:.0f} km. You '.format(aacgmv2.high_alt_coeff),
+                            'must either use field-line tracing (trace=True ',
+                            'or allowtrace=True) or indicate you know this ',
+                            'is a bad idea'])
             logging.error(estr)
             return lat_out, lon_out, r_out
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -101,6 +101,7 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
         the Earth (km)
     """
     import aacgmv2._aacgmv2 as c_aacgmv2
+    import aacgmv2
 
     # Test time
     if isinstance(dtime, dt.date):
@@ -126,9 +127,9 @@ def convert_latlon(in_lat, in_lon, height, dtime, code="G2A"):
            code.find("ALLOWTRACE") < 0 and code.find("BADIDEA") < 0):
             estr = ''.join(['coefficients are not valid for altitudes above ',
                             '{:.0f} km. You '.format(aacgmv2.high_alt_coeff),
-                            'must either use field-line tracing (trace=True '
-                            'or allowtrace=True) or indicate you know this '
-                            'is a bad idea'])
+                            'must either use field-line tracing (trace=True or',
+                            ' allowtrace=True) or indicate you know this is a',
+                            ' bad idea'])
             logging.error(estr)
             return lat_out, lon_out, r_out
 
@@ -209,6 +210,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
     At least one of in_lat, in_lon, and height must be a list or array.
     """
     import aacgmv2._aacgmv2 as c_aacgmv2
+    import aacgmv2
 
     # Recast the data as numpy arrays
     in_lat = np.array(in_lat)
@@ -265,9 +267,9 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, code="G2A"):
            and code.find("ALLOWTRACE") < 0 and code.find("BADIDEA") < 0):
             estr = ''.join(['coefficients are not valid for altitudes above ',
                             '{:.0f} km. You '.format(aacgmv2.high_alt_coeff),
-                            'must either use field-line tracing (trace=True ',
-                            'or allowtrace=True) or indicate you know this ',
-                            'is a bad idea'])
+                            'must either use field-line tracing (trace=True or',
+                            ' allowtrace=True) or indicate you know this is a ',
+                            'bad idea'])
             logging.error(estr)
             return lat_out, lon_out, r_out
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,30 +18,6 @@ environment:
       PYTHON_HOME: C:\python27-x64
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '64'
-    - TOXENV: '3.4-buildonly-nocover'
-      TOXPYTHON: C:\python34\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-    - TOXENV: '3.4-buildonly-nocover'
-      TOXPYTHON: C:\python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-    - TOXENV: '3.5-buildonly-nocover'
-      TOXPYTHON: C:\python35\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-    - TOXENV: '3.5-buildonly-nocover'
-      TOXPYTHON: C:\python35-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
     - TOXENV: '3.6-buildonly-nocover'
       TOXPYTHON: C:\python36\python.exe
       WINDOWS_SDK_VERSION: v7.1
@@ -54,13 +30,25 @@ environment:
       PYTHON_HOME: C:\python36-x64
       PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '64'
+    - TOXENV: '3.7-buildonly-nocover'
+      TOXPYTHON: C:\python37\python.exe
+      WINDOWS_SDK_VERSION: v7.1
+      PYTHON_HOME: C:\python37
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '32'
+    - TOXENV: '3.7-buildonly-nocover'
+      TOXPYTHON: C:\python37-x64\python.exe
+      WINDOWS_SDK_VERSION: v7.1
+      PYTHON_HOME: C:\python37-x64
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '64'
     - TOXENV: check
       PYTHON_HOME: C:\Python27
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '32'
     - TOXENV: '2.7-nocover'
       TOXPYTHON: C:\python27\python.exe
-      WINDOWS_SDK_VERSION: v7.0
+
       PYTHON_HOME: C:\python27
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '32'
@@ -70,31 +58,9 @@ environment:
       PYTHON_HOME: C:\python27-x64
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '64'
-    - TOXENV: '3.4-nocover'
-      TOXPYTHON: C:\python34\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-    - TOXENV: '3.4-nocover'
-      TOXPYTHON: C:\python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-    - TOXENV: '3.5-nocover'
-      TOXPYTHON: C:\python35\python.exe
-      PYTHON_HOME: C:\python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-    - TOXENV: '3.5-nocover'
-      TOXPYTHON: C:\python35-x64\python.exe
-      PYTHON_HOME: C:\python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
     - TOXENV: '3.6-nocover'
       TOXPYTHON: C:\python36\python.exe
-      WINDOWS_SDK_VERSION: v7.0
+
       PYTHON_HOME: C:\python36
       PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '32'
@@ -103,6 +69,18 @@ environment:
       WINDOWS_SDK_VERSION: v7.1
       PYTHON_HOME: C:\python36-x64
       PYTHON_VERSION: '3.6'
+      PYTHON_ARCH: '64'
+    - TOXENV: '3.7-nocover'
+      TOXPYTHON: C:\python37\python.exe
+
+      PYTHON_HOME: C:\python37
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '32'
+    - TOXENV: '3.7-nocover'
+      TOXPYTHON: C:\python37-x64\python.exe
+      WINDOWS_SDK_VERSION: v7.1
+      PYTHON_HOME: C:\python37-x64
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '64'
 init:
   - ps: echo $env:TOXENV
@@ -136,9 +114,8 @@ matrix:
     - TOXENV: '3.6-nocover'
     - TOXENV: '3.6,codecov'
     - TOXENV: '2.7-buildonly-nocover'
-    - TOXENV: '3.4-buildonly-nocover'
-    - TOXENV: '3.5-buildonly-nocover'
     - TOXENV: '3.6-buildonly-nocover'
+    - TOXENV: '3.7-buildonly-nocover'
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,14 +108,9 @@ on_failure:
   - ps: get-content .tox\*\log\*
 artifacts:
   - path: dist\*
-matrix:
-  allow_failures:
-    - TOXENV: 'check'
-    - TOXENV: '3.6-nocover'
-    - TOXENV: '3.6,codecov'
-    - TOXENV: '2.7-buildonly-nocover'
-    - TOXENV: '3.6-buildonly-nocover'
-    - TOXENV: '3.7-buildonly-nocover'
+#matrix:
+#  allow_failures:
+#    - TOXENV: '2.7-buildonly-nocover'
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,9 +108,10 @@ on_failure:
   - ps: get-content .tox\*\log\*
 artifacts:
   - path: dist\*
-#matrix:
-#  allow_failures:
-#    - TOXENV: '2.7-buildonly-nocover'
+matrix:
+  allow_failures:
+    - TOXENV: '2.7-nocover'
+    - TOXENV: '3.7-nocover'
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 

--- a/c_aacgmv2/src/aacgmlib_v2.c
+++ b/c_aacgmv2/src/aacgmlib_v2.c
@@ -598,6 +598,7 @@ int convert_geo_coord_v2(double lat_in, double lon_in, double height_in,
     printf("** HEIGHT INTERPOLATION **\n");
     #endif
 
+
     for (i=0; i<NCOORD; i++) {
       for (j=0; j<AACGM_KMAX;j++) {
         /* change to allow general polynomial approximation */
@@ -651,7 +652,7 @@ int convert_geo_coord_v2(double lat_in, double lon_in, double height_in,
       z += cint[k][2][flag]*ylmval[k];
     }
   }
- 
+
   /* COMMENT: SGS
    * 
    * This answers one of my questions about how the coordinates for AACGM are
@@ -667,6 +668,7 @@ int convert_geo_coord_v2(double lat_in, double lon_in, double height_in,
    */
   if (flag == 0) {
     fac = x*x + y*y;
+
     if (fac > 1.) {
       /* we are in the forbidden region and the solution is undefined */
       *lat_out = HUGE_VAL;
@@ -967,7 +969,7 @@ int AACGM_v2_LoadCoefs(int year)
 */
 
 int AACGM_v2_Convert(double in_lat, double in_lon, double height,
-                  double *out_lat, double *out_lon, double *r, int code)
+		     double *out_lat, double *out_lon, double *r, int code)
 {
   int err;
   int order=10;   /* pass in so a lower order would be allowed? */
@@ -1028,7 +1030,7 @@ int AACGM_v2_Convert(double in_lat, double in_lon, double height,
   /* all inputs are geocentric */
   err = convert_geo_coord_v2(in_lat,in_lon,height, out_lat,out_lon, code,order);
   /* all outputs are geocentric */
-
+  
   if ((code & A2G) == 0) {    /* forward: G2A */
     *r = (height + RE)/RE;    /* geocentric radial distance in RE */
   } else {                    /* inverse: A2G */
@@ -1335,7 +1337,7 @@ int AACGM_v2_Trace(double lat_in, double lon_in, double alt,
 {
   int err, kk, idir, below;
   unsigned long k,niter;
-  double ds, dsRE, dsRE0, eps, Lshell;
+  double ds, dsRE, dsRE0, eps, Lshell, test_dist;
   double rtp[3],xyzg[3],xyzm[3],xyzc[3],xyzp[3];
 
   /* set date for IGRF model */
@@ -1381,21 +1383,34 @@ int AACGM_v2_Trace(double lat_in, double lon_in, double alt,
   ; Also making sure that stepsize does not go to zero
   */
   below = 0;
-  while (!below && idir*xyzm[2] < 0.) {
+  test_dist = idir * xyzm[2];
+  while (!below && test_dist < 0.0) {
 
     for (kk=0;kk<3;kk++) xyzp[kk] = xyzg[kk]; /* save as previous */
 
     AACGM_v2_RK45(xyzg, idir, &dsRE, eps, 1); /* set to 0 for RK4: /noadapt) */
-
+    
     /* make sure that stepsize does not go to zero */
     if (dsRE*RE < 1e-2) dsRE = 1e-2/RE;
 
     /* convert to magnetic Dipole coordinates */
     geo2mag(xyzg, xyzm);
 
+    /* Trace solution is diverging */
+    if(test_dist > idir * xyzm[2])
+      {
+	*lat_out = NAN;
+	*lon_out = NAN;
+
+	err = -1;
+	return(err);
+      }
+
     below = ((xyzg[0]*xyzg[0]+xyzg[1]*xyzg[1]+xyzg[2]*xyzg[2]) <
              (RE+alt)*(RE+alt)/(RE*RE));
     k++;
+
+    test_dist = idir * xyzm[2];
   }
   niter = k;
 

--- a/ci/appveyor-bootstrap.py
+++ b/ci/appveyor-bootstrap.py
@@ -20,14 +20,12 @@ BASE_URL = "https://www.python.org/ftp/python/"
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
 GET_PIP_PATH = "C:\get-pip.py"
 URLS = {
-    ("2.7", "64"): BASE_URL + "2.7.14/python-2.7.14.amd64.msi",
-    ("2.7", "32"): BASE_URL + "2.7.14/python-2.7.14.msi",
-    ("3.4", "64"): BASE_URL + "3.4.8/python-3.4.8.amd64.msi",
-    ("3.4", "32"): BASE_URL + "3.4.8/python-3.4.8.msi",
-    ("3.5", "64"): BASE_URL + "3.5.5/python-3.5.5-amd64.exe",
-    ("3.5", "32"): BASE_URL + "3.5.5/python-3.5.5.exe",
+    ("2.7", "64"): BASE_URL + "2.7.14/python-2.7.16.amd64.msi",
+    ("2.7", "32"): BASE_URL + "2.7.14/python-2.7.16.msi",
     ("3.6", "64"): BASE_URL + "3.6.4/python-3.6.4-amd64.exe",
     ("3.6", "32"): BASE_URL + "3.6.4/python-3.6.4.exe",
+    ("3.7", "64"): BASE_URL + "3.7/python-3.7.amd64.msi",
+    ("3.7", "32"): BASE_URL + "3.7/python-3.7.msi",
 }
 INSTALL_CMD = {
     # Commands are allowed to fail only if they are not the last command.
@@ -38,13 +36,10 @@ INSTALL_CMD = {
     "2.7": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}",
              "TARGETDIR={home}"]],
-    "3.4": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}",
-             "TARGETDIR={home}"]],
-    "3.5": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}",
-             "TARGETDIR={home}"]],
     "3.6": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
+            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}",
+             "TARGETDIR={home}"]],
+    "3.7": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
             ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}",
              "TARGETDIR={home}"]],
 }

--- a/ci/appveyor-with-compiler.cmd
+++ b/ci/appveyor-with-compiler.cmd
@@ -23,7 +23,7 @@ SET WIN_WDK="c:\Program Files (x86)\Windows Kits\10\Include\wdf"
 ECHO SDK: %WINDOWS_SDK_VERSION% ARCH: %PYTHON_ARCH%
 
 
-IF "%PYTHON_VERSION%"=="3.5" (
+IF "%PYTHON_VERSION%"=="3.6" (
     IF EXIST %WIN_WDK% (
         REM See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
         REN %WIN_WDK% 0wdf

--- a/ci/templates/.travis.yml
+++ b/ci/templates/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
   - "3.6"
+  - "3.7"
 sudo: false
 env:
   global:

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -90,14 +90,9 @@ on_failure:
   - ps: get-content .tox\*\log\*
 artifacts:
   - path: dist\*
-matrix:
-  allow_failures:
-    - TOXENV: 'check'
-    - TOXENV: '3.6-nocover'
-    - TOXENV: '3.6,codecov'
-    - TOXENV: '2.7-buildonly-nocover'
-    - TOXENV: '3.6-buildonly-nocover'
-    - TOXENV: '3.7-buildonly-nocover'
+#matrix:
+#  allow_failures:
+#    - TOXENV: '2.7-buildonly-nocover'
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -90,9 +90,10 @@ on_failure:
   - ps: get-content .tox\*\log\*
 artifacts:
   - path: dist\*
-#matrix:
-#  allow_failures:
-#    - TOXENV: '2.7-buildonly-nocover'
+matrix:
+  allow_failures:
+    - TOXENV: '2.7-nocover'
+    - TOXENV: '3.7-nocover'
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -18,30 +18,6 @@ environment:
       PYTHON_HOME: C:\python27-x64
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '64'
-    - TOXENV: '3.4-buildonly-nocover'
-      TOXPYTHON: C:\python34\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-    - TOXENV: '3.4-buildonly-nocover'
-      TOXPYTHON: C:\python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-    - TOXENV: '3.5-buildonly-nocover'
-      TOXPYTHON: C:\python35\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-    - TOXENV: '3.5-buildonly-nocover'
-      TOXPYTHON: C:\python35-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
     - TOXENV: '3.6-buildonly-nocover'
       TOXPYTHON: C:\python36\python.exe
       WINDOWS_SDK_VERSION: v7.1
@@ -54,17 +30,25 @@ environment:
       PYTHON_HOME: C:\python36-x64
       PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '64'
+    - TOXENV: '3.7-buildonly-nocover'
+      TOXPYTHON: C:\python37\python.exe
+      WINDOWS_SDK_VERSION: v7.1
+      PYTHON_HOME: C:\python37
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '32'
+    - TOXENV: '3.7-buildonly-nocover'
+      TOXPYTHON: C:\python37-x64\python.exe
+      WINDOWS_SDK_VERSION: v7.1
+      PYTHON_HOME: C:\python37-x64
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '64'
     - TOXENV: check
       PYTHON_HOME: C:\Python27
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '32'
-{% for env, config in tox_environments|dictsort %}{% if config.python in ('python2.6', 'python2.7', 'python3.4', 'python3.5', 'python3.6') and not config.cover %}
+{% for env, config in tox_environments|dictsort %}{% if config.python in ('python2.6', 'python2.7', 'python3.6', 'python3.7') and not config.cover %}
     - TOXENV: '{{ env }}{% if config.cover %},codecov{% endif %}'
       TOXPYTHON: C:\{{ config.python.replace('.', '') }}\python.exe
-      {%- if config.python != 'python3.5' %}
-
-      WINDOWS_SDK_VERSION: v7.{{ '1' if config.python[-1] == '3' else '0' }}
-      {%- endif %}
 
       PYTHON_HOME: C:\{{ config.python.replace('.', '') }}
       PYTHON_VERSION: '{{ config.python[-3:] }}'
@@ -112,9 +96,8 @@ matrix:
     - TOXENV: '3.6-nocover'
     - TOXENV: '3.6,codecov'
     - TOXENV: '2.7-buildonly-nocover'
-    - TOXENV: '3.4-buildonly-nocover'
-    - TOXENV: '3.5-buildonly-nocover'
     - TOXENV: '3.6-buildonly-nocover'
+    - TOXENV: '3.7-buildonly-nocover'
 ### To enable remote debugging uncomment this:
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 

--- a/ci/templates/tox.ini
+++ b/ci/templates/tox.ini
@@ -16,7 +16,6 @@ passenv =
     *
 deps =
     pytest
-    logbook
     numpy
 commands =
     python setup.py clean --all build_ext --force --inplace

--- a/ci/templates/tox.ini
+++ b/ci/templates/tox.ini
@@ -53,7 +53,7 @@ passenv =
     *
 
 [testenv:check]
-basepython = python3.4
+basepython = python3.6
 deps =
     docutils
     check-manifest
@@ -97,7 +97,7 @@ commands =
     coveralls --build-root=. --include=src --dump=extension-coveralls.json []
 
 [testenv:report]
-basepython = python3.4
+basepython = python3.6
 deps = coverage
 skip_install = true
 usedevelop = false
@@ -148,22 +148,14 @@ deps =
 skip_install = true
 commands =
 
-[testenv:3.4-buildonly-nocover]
-basepython = {env:TOXPYTHON:python3.4}
-deps =
-skip_install = true
-commands =
-
-[testenv:3.5-buildonly-nocover]
-basepython = {env:TOXPYTHON:python3.5}
-deps =
-skip_install = true
-commands =
-
 [testenv:3.6-buildonly-nocover]
 basepython = {env:TOXPYTHON:python3.6}
 deps =
 skip_install = true
 commands =
 
-
+[testenv:3.7-buildonly-nocover]
+basepython = {env:TOXPYTHON:python3.7}
+deps =
+skip_install = true
+commands =

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,8 @@ if os.getenv('SPELLCHECK'):
 source_suffix = '.rst'
 master_doc = 'index'
 project = u'AACGM-v2 Python library'
-year = u'2015'
-author = u'Angeline G. Burrell, Christer van der Meeren'
+year = u'2019'
+author = u'Angeline G. Burrell, Christer van der Meeren, Karl M. Laundal'
 copyright = '{0}, {1}'.format(year, author)
 version = release = u'2.5.2'
 # on_rtd is whether we are on readthedocs.org

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ project = u'AACGM-v2 Python library'
 year = u'2015'
 author = u'Angeline G. Burrell, Christer van der Meeren'
 copyright = '{0}, {1}'.format(year, author)
-version = release = u'2.5.1'
+version = release = u'2.5.2'
 # on_rtd is whether we are on readthedocs.org
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,7 +16,7 @@ When you have NumPy, install this package at the command line using
 The package has been tested with the following setups (others might work, too):
 
 * Mac (64 bit), Windows (32/64 bit), and Linux (64 bit)
-* Python 2.7, 3.6, and 3.7
+* Python 2.7 (except Windows), 3.6, and 3.7 (except Windows 64 bit)
 
 .. [1] pip is included with Python 2 from v2.7.16 and Python 3 from v3.6. If you
        don't have pip,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,8 +16,8 @@ When you have NumPy, install this package at the command line using
 The package has been tested with the following setups (others might work, too):
 
 * Mac (64 bit), Windows (32/64 bit), and Linux (64 bit)
-* Python 2.7, 3.4, 3.5, and 3.6
+* Python 2.7, 3.6, and 3.7
 
-.. [1] pip is included with Python 2 from v2.7.9 and Python 3 from v3.4. If you
+.. [1] pip is included with Python 2 from v2.7.16 and Python 3 from v3.6. If you
        don't have pip,
        `get it here <http://pip.readthedocs.org/en/stable/installing/>`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,9 +60,8 @@ multi_line_output=0
 
 python_versions =
     2.7
-    3.4
-    3.5
     3.6
+    3.7
 
 #dependencies =
 

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Scientific/Engineering :: Physics',
         'Topic :: Utilities',
@@ -69,7 +68,6 @@ setup(
     ],
     install_requires=[
         'numpy',
-        'logbook',
     ],
     extras_require={'test':['pytest'],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,10 @@ envlist =
     check,
     2.7,
     2.7-nocover,
-    3.4,
-    3.4-nocover,
-    3.5,
-    3.5-nocover,
     3.6,
     3.6-nocover,
+    3.7,
+    3.7-nocover,
     report,
     docs
 
@@ -58,7 +56,7 @@ passenv =
     *
 
 [testenv:check]
-basepython = python3.4
+basepython = python3.6
 deps =
     docutils
     check-manifest
@@ -102,7 +100,7 @@ commands =
     coveralls --build-root=. --include=src --dump=extension-coveralls.json []
 
 [testenv:report]
-basepython = python3.4
+basepython = python3.6
 deps = coverage
 skip_install = true
 usedevelop = false
@@ -133,40 +131,6 @@ deps =
 [testenv:2.7-nocover]
 basepython = {env:TOXPYTHON:python2.7}
 
-[testenv:3.4]
-basepython = {env:TOXPYTHON:python3.4}
-setenv =
-    {[testenv]setenv}
-    WITH_COVERAGE=yes
-    PY_CCOV=-coverage
-usedevelop = true
-commands =
-    python setup.py clean --all build_ext --force --inplace
-    {posargs:py.test --cov --cov-report=term-missing -vv --doctest-glob='*.rst'}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-[testenv:3.4-nocover]
-basepython = {env:TOXPYTHON:python3.4}
-
-[testenv:3.5]
-basepython = {env:TOXPYTHON:python3.5}
-setenv =
-    {[testenv]setenv}
-    WITH_COVERAGE=yes
-    PY_CCOV=-coverage
-usedevelop = true
-commands =
-    python setup.py clean --all build_ext --force --inplace
-    {posargs:py.test --cov --cov-report=term-missing -vv --doctest-glob='*.rst'}
-deps =
-    {[testenv]deps}
-    pytest-cov
-
-[testenv:3.5-nocover]
-basepython = {env:TOXPYTHON:python3.5}
-
 [testenv:3.6]
 basepython = {env:TOXPYTHON:python3.6}
 setenv =
@@ -184,21 +148,26 @@ deps =
 [testenv:3.6-nocover]
 basepython = {env:TOXPYTHON:python3.6}
 
+[testenv:3.7]
+basepython = {env:TOXPYTHON:python3.7}
+setenv =
+    {[testenv]setenv}
+    WITH_COVERAGE=yes
+    PY_CCOV=-coverage
+usedevelop = true
+commands =
+    python setup.py clean --all build_ext --force --inplace
+    {posargs:py.test --cov --cov-report=term-missing -vv --doctest-glob='*.rst'}
+deps =
+    {[testenv]deps}
+    pytest-cov
+
+[testenv:3.7-nocover]
+basepython = {env:TOXPYTHON:python3.7}
+
 
 [testenv:2.7-buildonly-nocover]
 basepython = {env:TOXPYTHON:python2.7}
-deps =
-skip_install = true
-commands =
-
-[testenv:3.4-buildonly-nocover]
-basepython = {env:TOXPYTHON:python3.4}
-deps =
-skip_install = true
-commands =
-
-[testenv:3.5-buildonly-nocover]
-basepython = {env:TOXPYTHON:python3.5}
 deps =
 skip_install = true
 commands =
@@ -209,4 +178,8 @@ deps =
 skip_install = true
 commands =
 
-
+[testenv:3.7-buildonly-nocover]
+basepython = {env:TOXPYTHON:python3.7}
+deps =
+skip_install = true
+commands =

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ passenv =
     *
 deps =
     pytest
-    logbook
     numpy
 commands =
     python setup.py clean --all build_ext --force --inplace


### PR DESCRIPTION
# Description

Added a high-altitude limit for tracing to warn the users against using these coordinates in the magnetosphere and advise them about the potential for the tracing code to hang at extreme altitudes.

Additional fixes include changing the version support to 2.7, 3.6, and 3.7, removing the logbook dependency, and improving the unit test class structures

Fixes #35 and #33 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

This has been tested by:
- Determining the place where the C code was hanging
- Discussing the appropriate altitude extent of the coordinate system
- Running the code over the globe at a range of high altitudes using the TRACE method
 
The expected behaviour can be reproduced by running the following tests:

```
import datetime as dt
import aacgmv2

dtime = dt.datetime(2015, 1, 1, 0, 0, 0)
code = 'G2A|TRACE'
aacgmv2.get_aacgm_coord(90, 60, 7000, dtime, code)
```
This will produce outputs of np.nan for mlat, mlon, and mlt with the error message:
> ERROR:aacgmv2_logger:these coordinates are not intended for the magnetosphere! You must indicate that you know this is a bad idea.  If you continue, it is possible that the code will hang.

To run at this location anyway:
```
code = 'G2A|TRACE|BADIDEA'
aacgmv2.get_aacgm_coord(90, 60, 7000, dtime, code)
```
This provides a mlat=84.6218, mlon=175.2536, mlt=6.4608.  If you run this without tracing, but with the badidea flag, you reproduce the previous suspect output (using coefficients):
```
code = 'G2A|BADIDEA'
aacgmv2.get_aacgm_coord(90, 60, 7000, dtime, code)
```
This provides a mlat=-85.429987, mlon=131.304861, mlt=3.5308.

**Test Configuration**:
* OS X Sierra and Mojave

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst``