### PR TITLE
Environment variable setting/warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 * Added FutureWarning to deprecated functions
 * Updated names in licenses
 * Moved module structure routine tests to their own class
+* Added logic to avoid reseting environment variables if not necessary
 
 
 2.5.1 (2018-10-19)

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -53,20 +53,24 @@ IGRF_COEFFS = _os.path.join(_os.path.realpath(_os.path.dirname(__file__)),
                             'magmodel_1590-2015.txt')
 
 # If not defined, set the IGRF and AACGM environment variables
-reset_warn = False
+__reset_warn__ = False
 if 'IGRF_COEFFS' in _os.environ.keys():
-    stderr.write("resetting environment variable IGRF_COEFFS in python "
-                 + "script\n")
-    reset_warn = True
+    # Check and see if this environment variable is the same or different
+    if not _os.environ['IGRF_COEFFS'] == IGRF_COEFFS:
+        stderr.write("".join(["resetting environment variable IGRF_COEFFS in ",
+                              "python script\n"]))
+        __reset_warn__ = True
 _os.environ['IGRF_COEFFS'] = IGRF_COEFFS
 
 if 'AACGM_v2_DAT_PREFIX' in _os.environ.keys():
-    stderr.write("resetting environment variable AACGM_v2_DAT_PREFIX in " +
-                 "python script\n")
-    reset_warn = True
+    # Check and see if this environment variable is the same or different
+    if not _os.environ['AACGM_v2_DAT_PREFIX'] == AACGM_v2_DAT_PREFIX:
+        stderr.write("".join(["resetting environment variable ",
+                              "AACGM_v2_DAT_PREFIX in python script\n"]))
+        __reset_warn__ = True
 _os.environ['AACGM_v2_DAT_PREFIX'] = AACGM_v2_DAT_PREFIX
 
-if reset_warn:
+if __reset_warn__:
     stderr.write("non-default coefficient files may be specified by running " +
                  "aacgmv2.wrapper.set_coeff_path before any other functions\n")
 # Imports

--- a/aacgmv2/tests/test_environ_aacgmv2.py
+++ b/aacgmv2/tests/test_environ_aacgmv2.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+from __future__ import division, absolute_import, unicode_literals
+
+import os
+import pytest
+
+@pytest.mark.skip(reason='only works for first import')
+class TestPyEnviron:
+    def setup(self):
+        self.igrf_path = os.path.join("aacgmv2", "aacgmv2",
+                                      "magmodel_1590-2015.txt")
+        self.aacgm_path = os.path.join("aacgmv2", "aacgmv2", "aacgm_coeffs",
+                                       "aacgm_coeffs-12-")
+
+    def teardown(self):
+        del self.igrf_path, self.aacgm_path
+
+    def reset_evar(self, evar):
+        """ Reset the environment variables """
+
+        for coeff_key in evar:
+            if coeff_key in os.environ.keys():
+                del os.environ[coeff_key]
+
+        for coeff_key in evar:
+            assert coeff_key not in os.environ.keys()
+
+    def test_good_coeff(self, aacgm_test=None, igrf_test=None):
+        """ Test the coefficient path/prefixes """
+
+        # Set the defaults
+        if aacgm_test is None:
+            aacgm_test = self.aacgm_path
+        if igrf_test is None:
+            igrf_test = self.igrf_path
+
+        # Perform the test
+        if aacgm_test.find(self.aacgm_path) < 0:
+            raise AssertionError('BAD AACGMV PATH')
+
+        if igrf_test.find(self.igrf_path) < 0:
+            raise AssertionError('BAD IGRF PATH')
+
+
+    def test_top_parameters_default(self):
+        """Test default module coefficients"""
+
+        # Import AACGMV2 after removing any possible preset env variables
+        self.reset_evar(evar=['AACGM_v2_DAT_PREFIX', 'IGRF_COEFFS'])
+        import aacgmv2
+
+        self.test_good_coeff(aacgmv2.AACGM_v2_DAT_PREFIX, aacgmv2.IGRF_COEFFS)
+
+        assert not aacgmv2.__reset_warn__
+        del aacgmv2
+
+    def test_top_parameters_reset_aacgm(self):
+        """Test module reset of AACGM coefficient path"""
+
+        self.reset_evar(evar=['AACGM_v2_DAT_PREFIX'])
+        os.environ['AACGM_v2_DAT_PREFIX'] = 'test_prefix'
+
+        import aacgmv2
+
+        self.test_good_coeff(aacgmv2.AACGM_v2_DAT_PREFIX, aacgmv2.IGRF_COEFFS)
+
+        assert aacgmv2.__reset_warn__
+        del aacgmv2
+
+    def test_top_parameters_reset_igrf(self):
+        """Test module reset of IGRF coefficient path"""
+
+        self.reset_evar(evar=['IGRF_COEFFS'])
+        os.environ['IGRF_COEFFS'] = 'test_prefix'
+
+        import aacgmv2
+
+        self.test_good_coeff(aacgmv2.AACGM_v2_DAT_PREFIX, aacgmv2.IGRF_COEFFS)
+
+        assert aacgmv2.__reset_warn__
+        del aacgmv2
+
+    def test_top_parameters_reset_both(self):
+        """Test module reset of both coefficient paths"""
+
+        os.environ['AACGM_v2_DAT_PREFIX'] = 'test_prefix1'
+        os.environ['IGRF_COEFFS'] = 'test_prefix2'
+
+        import aacgmv2
+
+        self.test_good_coeff(aacgmv2.AACGM_v2_DAT_PREFIX, aacgmv2.IGRF_COEFFS)
+
+        assert aacgmv2.__reset_warn__
+        del aacgmv2
+
+    def test_top_parameters_set_same(self):
+        """Test module non-reset with outside def of both coefficient paths"""
+
+        from aacgmv2 import __file__ as file_path
+
+        coeff_path = os.path.realpath(os.path.dirname(file_path))
+        os.environ['AACGM_v2_DAT_PREFIX'] = os.path.join(coeff_path,
+                                                         self.aacgm_path)
+        os.environ['IGRF_COEFFS'] = os.path.join(coeff_path, self.igrf_path)
+
+        import aacgmv2
+
+        self.test_good_coeff(aacgmv2.AACGM_v2_DAT_PREFIX, aacgmv2.IGRF_COEFFS)
+
+        assert not aacgmv2.__reset_warn__
+        del aacgmv2

--- a/aacgmv2/tests/test_struct_aacgmv2.py
+++ b/aacgmv2/tests/test_struct_aacgmv2.py
@@ -164,19 +164,3 @@ class TestTopStructure(TestModuleStructure):
         self.reference_list = ["_aacgmv2", "wrapper",
                                "deprecated", "__main__"]
         self.test_modules()
-
-    @classmethod
-    def test_top_parameters(self):
-        """Test module constants"""
-        from os import path
-
-        path1 = path.join("aacgmv2", "aacgmv2", "aacgm_coeffs",
-                          "aacgm_coeffs-12-")
-        if aacgmv2.AACGM_v2_DAT_PREFIX.find(path1) < 0:
-            raise AssertionError()
-
-        path2 = path.join("aacgmv2", "aacgmv2", "magmodel_1590-2015.txt")
-        if aacgmv2.IGRF_COEFFS.find(path2) < 0:
-            raise AssertionError()
-
-        del path1, path2


### PR DESCRIPTION
# Description
Updated logic for reseting environment variables so that it is only done when necessary.

Fixes #37 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- If you have the environment variables set on your system, run this test.  You will not receive any warnings now:
```
import os
for coeff in ['AACGM_v2_DAT_PREFIX', 'IGRF_COEFFS']:
    if coeff in os.environ.keys():
        del os.environ[coeff]

import aacgmv2
```

- If you normally don't normally receive any warnings, this will produce them:
```
import os

os.environ['AACGM_v2_DAT_PREFIX'] = 'test1'
os.environ['IGRF_COEFFS'] = 'test2'

import aacgmv2
```
You will see in stderr:
> resetting environment variable IGRF_COEFFS in python script
> resetting environment variable AACGM_v2_DAT_PREFIX in python script
> non-default coefficient files may be specified by running aacgmv2.wrapper.set_coeff_path before any other functions

- To test and make sure that no environment variables are being set unnecessarily:
```
import os
path_to_aacgmv2 = "set this to whatever your local path is"
os.environ['AACGM_v2_DAT_PREFIX'] = os.path.join(path_to_aacgmv2, "aacgmv2", "aacgmv2", "aacgm_coeffs", "aacgm_coeffs-12-")
os.environ['IGRF_COEFFS'] = 'test1'

import aacgmv2
```
You will see in stderr:
> resetting environment variable IGRF_COEFFS in python script
> non-default coefficient files may be specified by running aacgmv2.wrapper.set_coeff_path before any other functions

**Test Configuration**:
* OSX Mojave

# Checklist:
- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst``