### PR TITLE
NaN bug in vectorized functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 
 Changelog
 =========
+2.5.3 (2019-11-XX)
+-----------------------------------------
+* Changed log warning about array functions to info
+* Changed default method from `TRACE` to `ALLOWTRACE`
+* Added C wrappers for list input, removing inefficient use of `np.vectorize`
+
+
 2.5.2 (2019-08-27)
 -----------------------------------------
 * Added FutureWarning to deprecated functions

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Convert between AACGM and geographic coordinates::
     array([57.4721, 93.6214, 1.4816])
     >>> # AACGM to geo, mix arrays/numbers
     >>> np.array2string(np.array(aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G"))).replace('\n', '')
-    '[[82.9666, -74.3385], [-84.6652, 125.8401], [14.1244, 12.8771]]'
+    '[[82.9666, -74.3385] [-84.6652, 125.8401] [14.1244, 12.8771]]'
 
 Convert between AACGM and MLT::
 

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Convert between AACGM and geographic coordinates::
     >>> np.array(aacgmv2.get_aacgm_coord(60, 15, 300, dtime))
     array([57.4721, 93.6214, 1.4816])
     >>> # AACGM to geo, mix arrays/numbers
-    >>> np.array(aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G"))
-    array([[82.9666, -74.3385], [-84.6652, 125.8401], [14.1244, 12.8771]])
+    >>> np.array2string(np.array(aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G"))).replace('\n', '')
+    '[[82.9666, -74.3385], [-84.6652, 125.8401], [14.1244, 12.8771]]'
 
 Convert between AACGM and MLT::
 

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Convert between AACGM and geographic coordinates::
     >>> # geo to AACGM, single numbers
     >>> dtime = dt.datetime(2013, 11, 3)
     >>> np.array(aacgmv2.get_aacgm_coord(60, 15, 300, dtime))
-    array([57.4698, 93.6300, 1.4822])
+    array([57.4721, 93.6214, 1.4816])
     >>> # AACGM to geo, mix arrays/numbers
     >>> aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G")
     (array([82.9666, -74.3385]), array([-84.6652, 125.8401]), array([14.1244, 12.8771]))

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Convert between AACGM and geographic coordinates::
     >>> np.array(aacgmv2.get_aacgm_coord(60, 15, 300, dtime))
     array([57.4721, 93.6214, 1.4816])
     >>> # AACGM to geo, mix arrays/numbers
-    >>> aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G")
-    (array([82.9666, -74.3385]), array([-84.6652, 125.8401]), array([14.1244, 12.8771]))
+    >>> np.array(aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G"))
+    array([[82.9666, -74.3385], [-84.6652, 125.8401], [14.1244, 12.8771]])
 
 Convert between AACGM and MLT::
 
@@ -44,7 +44,7 @@ Convert between AACGM and MLT::
     >>> np.set_printoptions(formatter={'float_kind': lambda x:'{:.4f}'.format(x)})
     >>> # MLT to AACGM
     >>> dtime = dt.datetime(2013, 11, 3, 0, 0, 0)
-    >>> aacgmv2.convert_mlt([1.4822189, 12], dtime, m2a=True)
+    >>> np.array(aacgmv2.convert_mlt([1.4822189, 12], dtime, m2a=True))
     array([93.6300, -108.6033])
 
 If you don't know or use Python, you can also use the command line. See details

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Convert between AACGM and geographic coordinates::
     array([57.4721, 93.6214, 1.4816])
     >>> # AACGM to geo, mix arrays/numbers
     >>> np.array2string(np.array(aacgmv2.convert_latlon_arr([90, -90], 0, 0, dtime, method_code="A2G"))).replace('\n', '')
-    '[[82.9666, -74.3385] [-84.6652, 125.8401] [14.1244, 12.8771]]'
+    '[[82.9666 -74.3385] [-84.6652 125.8401] [14.1244 12.8771]]'
 
 Convert between AACGM and MLT::
 

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -42,6 +42,7 @@ wrapper.test_height
 wrapper.test_time
 deprecated.subsol
 _aacgmv2.convert
+_aacgmv2.convert_arr
 _aacgmv2.set_datetime
 _aacgmv2.mlt_convert
 _aacgmv2.mlt_convert_yrsec

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -45,8 +45,10 @@ _aacgmv2.convert
 _aacgmv2.convert_arr
 _aacgmv2.set_datetime
 _aacgmv2.mlt_convert
+_aacgmv2.mlt_convert_arr
 _aacgmv2.mlt_convert_yrsec
 _aacgmv2.inv_mlt_convert
+_aacgmv2.inv_mlt_convert_arr
 _aacgmv2.inv_mlt_convert_yrsec
 ---------------------------------------------------------------------------
 """

--- a/aacgmv2/aacgmv2module.c
+++ b/aacgmv2/aacgmv2module.c
@@ -368,10 +368,13 @@ out_lon : (list)\n\
     Output longitudes in degrees\n\
 out_r : (list)\n\
     Geocentric radial distances in Re\n\
+out_bad : (list)\n\
+    Indices at or greater than zero indicate filler data in previous outputs\n\
 \n\
 Notes \n\
 -----\n\
-Return values of inf are usually raised when an error was encountered\n", },
+Return values of -666 are used as filler values for lat/lon/r, while filler\n\
+values of -1 are used in out_bad if the output in out_lat/lon/r is good\n", },
   {"mlt_convert_arr", mltconvert_v2_arr, METH_VARARGS,
     "mlt_convert_arr(yr, mo, dy, hr, mt, sc, mlon)\n\
 \n\

--- a/aacgmv2/aacgmv2module.c
+++ b/aacgmv2/aacgmv2module.c
@@ -25,6 +25,10 @@
 
 PyObject *module;
 
+#ifndef PyInt_AsLong
+#define PyInt_AsLong PyLong_AsLong
+#endif
+
 static PyObject *aacgm_v2_setdatetime(PyObject *self, PyObject *args)
 {
   int year, month, day, hour, minute, second, err;

--- a/aacgmv2/aacgmv2module.c
+++ b/aacgmv2/aacgmv2module.c
@@ -59,9 +59,8 @@ static PyObject *aacgm_v2_convert_arr(PyObject *self, PyObject *args)
 
   double in_lat, in_lon, in_h, out_lat, out_lon, out_r;
 
-  PyObject *latIn, *lonIn, *hIn, *latOut, *lonOut, *rOut, *allOut;
-
-  raise_warn = 0;
+  PyObject *latIn, *lonIn, *hIn, *latOut, *lonOut, *rOut, *badOut, *allOut;
+  PyObject *badInt, *badFloat;
 
   /* Parse the input as a tuple */
   if(!PyArg_ParseTuple(args, "O!O!O!i", &PyList_Type, &latIn, &PyList_Type,
@@ -73,6 +72,9 @@ static PyObject *aacgm_v2_convert_arr(PyObject *self, PyObject *args)
   latOut = PyList_New(in_num);
   lonOut = PyList_New(in_num);
   rOut   = PyList_New(in_num);
+  badOut = PyList_New(in_num);
+  badInt = PyLong_FromLong((int long)(-1));
+  badFloat = PyFloat_FromDouble(-666.0);
 
   /* Cycle through all of the inputs */
   for(i=0; i<in_num; i++)
@@ -85,19 +87,25 @@ static PyObject *aacgm_v2_convert_arr(PyObject *self, PyObject *args)
       /* Call the AACGM routine */
       err = AACGM_v2_Convert(in_lat, in_lon, in_h, &out_lat, &out_lon,
 			     &out_r, code);
-      if(err < 0) raise_warn++;
-      
-      PyList_SetItem(latOut, i, PyFloat_FromDouble(out_lat));
-      PyList_SetItem(lonOut, i, PyFloat_FromDouble(out_lon));
-      PyList_SetItem(rOut, i, PyFloat_FromDouble(out_r));
+      if(err < 0)
+	{
+	  /* Python 3.7+ raises a SystemError when passing on inf */
+	  PyList_SetItem(badOut, i, PyLong_FromLong((int long)i));
+	  PyList_SetItem(latOut, i, badFloat);
+	  PyList_SetItem(lonOut, i, badFloat);
+	  PyList_SetItem(rOut, i, badFloat);
+	}
+      else
+	{
+	  PyList_SetItem(badOut, i, badInt);
+	  PyList_SetItem(latOut, i, PyFloat_FromDouble(out_lat));
+	  PyList_SetItem(lonOut, i, PyFloat_FromDouble(out_lon));
+	  PyList_SetItem(rOut, i, PyFloat_FromDouble(out_r));
+	}
     }
 
-  if(raise_warn > 0)
-    PyErr_Format(PyExc_RuntimeWarning,
-		 "AACGM_v2_Convert returned with error %d times", raise_warn);
-
   /* Set the output tuple */
-  allOut = PyTuple_Pack(3, latOut, lonOut, rOut);
+  allOut = PyTuple_Pack(4, latOut, lonOut, rOut, badOut);
   
   return allOut;
 }

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -63,16 +63,16 @@ def convert(lat, lon, alt, date=None, a2g=False, trace=False, allowtrace=False,
         Output longitude in degrees E
     """
 
-    dstr = "Deprecated routine, will be removed in version 2.6.  Recommend "
-    dstr += "using convert_latlon or convert_latlon_arr"
+    dstr = "".join(["Deprecated routine, will be removed in version 2.6.  ",
+                    "Recommend using convert_latlon or convert_latlon_arr"])
     warnings.warn(dstr, category=FutureWarning)
 
     if(np.array(alt).max() > 2000 and not trace and not allowtrace and
        not badidea):
-        estr = 'coefficients are not valid for altitudes above 2000 km. You'
-        estr += ' must either use field-line tracing (trace=True '
-        estr += 'or allowtrace=True) or indicate you know this is a bad idea'
-        estr += ' (badidea=True)'
+        estr = ''.join(['coefficients are not valid for altitudes above 2000 ',
+                        'km. You must either use field-line tracing (trace=',
+                        'True or allowtrace=True) or indicate you know this ',
+                        'is a bad idea (badidea=True)'])
         raise ValueError(estr)
 
     # construct a code from the boolian flags

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -86,6 +86,27 @@ class TestCAACGMV2:
 
         del lat_comp, lon_comp, r_comp
 
+    def test_convert_arr(self):
+        """Test convert_arr using from magnetic to geodetic coordinates"""
+        lat_comp = [30.7534, 50.0891]
+        lon_comp = [-94.1806, -77.3773]
+        r_comp = [1133.6241, 305.602877]
+
+        aacgmv2._aacgmv2.set_datetime(*self.date_args[0])
+        (self.mlat, self.mlon, self.rshell,
+         bad_ind) = aacgmv2._aacgmv2.convert_arr(self.lat_in, self.lon_in,
+                                                 self.alt_in,
+                                                 aacgmv2._aacgmv2.A2G)
+
+        assert len(self.mlat) == len(self.lat_in)
+        for i, ll in enumerate(self.mlat):
+            np.testing.assert_almost_equal(ll, lat_comp[i], decimal=4)
+            np.testing.assert_almost_equal(self.mlon[i], lon_comp[i], decimal=4)
+            np.testing.assert_almost_equal(self.rshell[i], r_comp[i], decimal=4)
+            assert bad_ind[i] == -1
+
+        del lat_comp, lon_comp, r_comp
+
     def test_convert_G2A_TRACE(self):
         """Test convert from geodetic to magnetic coordinates using trace"""
         code = aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -98,9 +98,16 @@ class TestDepLogging:
     def test_warning_below_ground_convert(self):
         """ Test that a warning is issued if altitude is below zero"""
 
-        aacgmv2.convert(*self.in_convert)
-        self.lout = self.log_capture.getvalue()
-        assert self.lout.find(self.lwarn) >= 0
+        with warnings.catch_warnings():
+            # Cause all warnings to be ignored
+            warnings.simplefilter("ignore")
+
+            # Trigger the below ground warning
+            aacgmv2.convert(*self.in_convert)
+
+            # Test the logging output
+            self.lout = self.log_capture.getvalue()
+            assert self.lout.find(self.lwarn) >= 0
 
 
 class TestDepAACGMV2:
@@ -121,9 +128,9 @@ class TestDepAACGMV2:
             warnings.simplefilter("ignore")
             self.lat, self.lon = aacgmv2.convert(60, 0, 300, self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 1
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
 
@@ -133,9 +140,9 @@ class TestDepAACGMV2:
             warnings.simplefilter("ignore")
             self.lat, self.lon = aacgmv2.convert([60], [0], [300], self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 1
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
 
@@ -144,9 +151,9 @@ class TestDepAACGMV2:
             self.lat, self.lon = aacgmv2.convert([60, 61], [0, 0], [300, 300],
                                                  self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)
 
@@ -157,9 +164,9 @@ class TestDepAACGMV2:
             self.lat, self.lon = aacgmv2.convert(np.array([60]), np.array([0]),
                                                  np.array([300]), self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 1
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
 
@@ -173,9 +180,9 @@ class TestDepAACGMV2:
                                                  np.array([300, 300]),
                                                  self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)
 
@@ -186,9 +193,9 @@ class TestDepAACGMV2:
             warnings.simplefilter("ignore")
             self.lat, self.lon = aacgmv2.convert([60, 61], 0, 300, self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)
 
@@ -199,48 +206,20 @@ class TestDepAACGMV2:
             self.lat, self.lon = aacgmv2.convert(np.array([60, 61]), 0, 300,
                                                  self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (2,)
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)
 
-    def test_convert_mult_array_mix(self):
+    def test_convert_mult_array_failure(self):
         """Test conversion for a multi-dim array and floats"""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            self.lat, self.lon = aacgmv2.convert(np.array([[60, 61, 62],
-                                                           [63, 64, 65]]), 0,
-                                                 300, self.dtime)
-
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (2, 3)
-        np.testing.assert_allclose(self.lat, [[58.2258, 59.3186, 60.4040],
-                                         [61.4820, 62.5528, 63.6164]],
-                                   rtol=1e-4)
-        np.testing.assert_allclose(self.lon, [[81.1685, 81.6140, 82.0872],
-                                         [82.5909, 83.1286, 83.7039]],
-                                   rtol=1e-4)
-
-    def test_convert_unequal_arra(self):
-        """Test conversion for unequal sized arrays"""
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            self.lat, self.lon = aacgmv2.convert(np.array([[60, 61, 62],
-                                                           [63, 64, 65]]),
-                                                 np.array([0]), np.array([300]),
-                                                 self.dtime)
-
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (2, 3)
-        np.testing.assert_allclose(self.lat, [[58.2258, 59.3186, 60.4040],
-                                              [61.4820, 62.5528, 63.6164]],
-                                   rtol=1e-4)
-        np.testing.assert_allclose(self.lon, [[81.1685, 81.6140, 82.0872],
-                                              [82.5909, 83.1286, 83.7039]],
-                                   rtol=1e-4)
+            with pytest.raises(ValueError):
+                self.lat, self.lon = aacgmv2.convert(np.array([[60, 61, 62],
+                                                               [63, 64, 65]]),
+                                                     0, 300, self.dtime)
 
     def test_convert_location_failure(self):
         """Test conversion with a bad location"""
@@ -248,10 +227,10 @@ class TestDepAACGMV2:
             warnings.simplefilter("ignore")
             self.lat, self.lon = aacgmv2.convert([0], [0], [0], self.dtime)
 
-        assert isinstance(self.lat, np.ndarray)
-        assert isinstance(self.lon, np.ndarray)
-        assert self.lat.shape == self.lon.shape and self.lat.shape == (1,)
-        assert np.all([np.isnan(self.lat), np.isnan(self.lon)])
+        assert isinstance(self.lat, list)
+        assert isinstance(self.lon, list)
+        assert len(self.lat) == len(self.lon) and len(self.lat) == 1
+        assert np.all([np.isinf(self.lat), np.isinf(self.lon)])
 
     def test_convert_time_failure(self):
         """Test conversion with a bad time"""

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -11,6 +11,9 @@ import warnings
 
 import aacgmv2
 
+if version_info.major == 2:
+    warnings.filterwarnings('error')
+
 class TestFutureDepWarning:
     def setup(self):
         # Initialize the routine to be tested

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -25,7 +25,7 @@ class TestFutureDepWarning:
         if self.test_routine is None:
             assert True
         else:
-            with warnings.catch_warnings(record=True) as w:
+            with warnings.catch_warnings(record=True) as wout:
                 # Cause all warnings to always be triggered.
                 warnings.simplefilter("always")
 
@@ -33,9 +33,9 @@ class TestFutureDepWarning:
                 self.test_routine(*self.test_args, **self.test_kwargs)
 
                 # Verify some things
-                assert len(w) == 1
-                assert issubclass(w[-1].category, FutureWarning)
-                assert "Deprecated routine" in str(w[-1].message)
+                assert len(wout) == 1
+                assert issubclass(wout[-1].category, FutureWarning)
+                assert "Deprecated routine" in str(wout[-1].message)
 
 
 class TestDepAACGMV2Warning(TestFutureDepWarning):

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -11,9 +11,6 @@ import warnings
 
 import aacgmv2
 
-if version_info.major == 2:
-    warnings.filterwarnings('error')
-
 class TestFutureDepWarning:
     def setup(self):
         # Initialize the routine to be tested
@@ -245,6 +242,7 @@ class TestDepAACGMV2:
                                                                [63, 64, 65]]),
                                                      0, 300, self.dtime)
 
+    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
     def test_convert_location_failure(self):
         """Test conversion with a bad location"""
         self.lat, self.lon = aacgmv2.convert([0], [0], [0], self.dtime)

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -242,7 +242,8 @@ class TestDepAACGMV2:
                                                                [63, 64, 65]]),
                                                      0, 300, self.dtime)
 
-    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
+    @pytest.mark.skipif(version_info.major == 2,
+                        reason='Not raised in Python 2')
     def test_convert_location_failure(self):
         """Test conversion with a bad location"""
         self.lat, self.lon = aacgmv2.convert([0], [0], [0], self.dtime)

--- a/aacgmv2/tests/test_dep_aacgmv2.py
+++ b/aacgmv2/tests/test_dep_aacgmv2.py
@@ -111,25 +111,6 @@ class TestDepLogging:
             self.lout = self.log_capture.getvalue()
             assert self.lout.find(self.lwarn) >= 0
 
-    @pytest.mark.skipif(version_info.major == 2,
-                        reason='Not raised in Python 2')
-    def test_warning_c_failure_convert(self):
-        """ Test that a warning is issued if the C routine exits with failure"""
-        self.lwarn = u"C Error encountered: "
-        self.in_convert[0] = [0]
-        self.in_convert[2] = [0]
-
-        with warnings.catch_warnings():
-            # Cause all warnings to be ignored
-            warnings.simplefilter("ignore")
-
-            # Trigger the C failure logger warning
-            aacgmv2.convert(*self.in_convert)
-
-            # Test the logging output
-            self.lout = self.log_capture.getvalue()
-            assert self.lout.find(self.lwarn) >= 0
-
 
 class TestDepAACGMV2:
     def setup(self):
@@ -149,8 +130,8 @@ class TestDepAACGMV2:
             warnings.simplefilter("ignore")
             self.lat, self.lon = aacgmv2.convert(60, 0, 300, self.dtime)
 
-        assert isinstance(self.lat, list)
-        assert isinstance(self.lon, list)
+        assert isinstance(self.lat, np.ndarray)
+        assert isinstance(self.lon, np.ndarray)
         assert len(self.lat) == len(self.lon) and len(self.lat) == 1
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
@@ -161,8 +142,8 @@ class TestDepAACGMV2:
             warnings.simplefilter("ignore")
             self.lat, self.lon = aacgmv2.convert([60], [0], [300], self.dtime)
 
-        assert isinstance(self.lat, list)
-        assert isinstance(self.lon, list)
+        assert isinstance(self.lat, np.ndarray)
+        assert isinstance(self.lon, np.ndarray)
         assert len(self.lat) == len(self.lon) and len(self.lat) == 1
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
@@ -172,8 +153,8 @@ class TestDepAACGMV2:
             self.lat, self.lon = aacgmv2.convert([60, 61], [0, 0], [300, 300],
                                                  self.dtime)
 
-        assert isinstance(self.lat, list)
-        assert isinstance(self.lon, list)
+        assert isinstance(self.lat, np.ndarray)
+        assert isinstance(self.lon, np.ndarray)
         assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)
@@ -185,8 +166,8 @@ class TestDepAACGMV2:
             self.lat, self.lon = aacgmv2.convert(np.array([60]), np.array([0]),
                                                  np.array([300]), self.dtime)
 
-        assert isinstance(self.lat, list)
-        assert isinstance(self.lon, list)
+        assert isinstance(self.lat, np.ndarray)
+        assert isinstance(self.lon, np.ndarray)
         assert len(self.lat) == len(self.lon) and len(self.lat) == 1
         np.testing.assert_allclose(self.lat, [58.2258], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685], rtol=1e-4)
@@ -201,8 +182,8 @@ class TestDepAACGMV2:
                                                  np.array([300, 300]),
                                                  self.dtime)
 
-        assert isinstance(self.lat, list)
-        assert isinstance(self.lon, list)
+        assert isinstance(self.lat, np.ndarray)
+        assert isinstance(self.lon, np.ndarray)
         assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)
@@ -214,8 +195,8 @@ class TestDepAACGMV2:
             warnings.simplefilter("ignore")
             self.lat, self.lon = aacgmv2.convert([60, 61], 0, 300, self.dtime)
 
-        assert isinstance(self.lat, list)
-        assert isinstance(self.lon, list)
+        assert isinstance(self.lat, np.ndarray)
+        assert isinstance(self.lon, np.ndarray)
         assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)
@@ -227,8 +208,8 @@ class TestDepAACGMV2:
             self.lat, self.lon = aacgmv2.convert(np.array([60, 61]), 0, 300,
                                                  self.dtime)
 
-        assert isinstance(self.lat, list)
-        assert isinstance(self.lon, list)
+        assert isinstance(self.lat, np.ndarray)
+        assert isinstance(self.lon, np.ndarray)
         assert len(self.lat) == len(self.lon) and len(self.lat) == 2
         np.testing.assert_allclose(self.lat, [58.2258, 59.3186], rtol=1e-4)
         np.testing.assert_allclose(self.lon, [81.1685, 81.6140], rtol=1e-4)

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -109,7 +109,7 @@ class TestConvertLatLonArr:
                                               self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i][0]], rtol=self.rtol)
@@ -122,7 +122,7 @@ class TestConvertLatLonArr:
                                               self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i][0]], rtol=self.rtol)
@@ -134,7 +134,7 @@ class TestConvertLatLonArr:
                                               self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.ref[i])
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.ref[i])
                 for i, oo in enumerate(self.out)]
 
         for i, oo in enumerate(self.out):
@@ -148,7 +148,7 @@ class TestConvertLatLonArr:
                                               self.dtime, self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i][0]], rtol=self.rtol)
@@ -161,7 +161,7 @@ class TestConvertLatLonArr:
                                               self.dtime, self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.ref[i])
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.ref[i])
                 for i, oo in enumerate(self.out)]
 
         for i, oo in enumerate(self.out):
@@ -174,7 +174,7 @@ class TestConvertLatLonArr:
                                               self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.ref[i])
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.ref[i])
                 for i, oo in enumerate(self.out)]
 
         for i, oo in enumerate(self.out):
@@ -187,7 +187,7 @@ class TestConvertLatLonArr:
                                               self.dtime, self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.ref[i])
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.ref[i])
                 for i, oo in enumerate(self.out)]
 
         for i, oo in enumerate(self.out):
@@ -208,7 +208,7 @@ class TestConvertLatLonArr:
                                               [3000], self.dtime, self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i]], rtol=self.rtol)
@@ -221,7 +221,7 @@ class TestConvertLatLonArr:
                                               [7000], self.dtime, self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i]], rtol=self.rtol)
@@ -261,7 +261,7 @@ class TestConvertLatLonArr:
                                               self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.ref[i])
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.ref[i])
                 for i, oo in enumerate(self.out)]
 
         for i, oo in enumerate(self.out):
@@ -373,7 +373,7 @@ class TestGetAACGMCoordArr:
                                                self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i][0]], rtol=self.rtol)
@@ -386,7 +386,7 @@ class TestGetAACGMCoordArr:
                                                self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i][0]], rtol=self.rtol)
@@ -398,7 +398,7 @@ class TestGetAACGMCoordArr:
                                                self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.lat_in)
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.lat_in)
                 for oo in self.out]
 
         for i, oo in enumerate(self.out):
@@ -413,7 +413,7 @@ class TestGetAACGMCoordArr:
 
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i][0]], rtol=self.rtol)
@@ -426,7 +426,7 @@ class TestGetAACGMCoordArr:
                                                self.dtime, self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.lat_in)
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.lat_in)
                 for oo in self.out]
 
         for i, oo in enumerate(self.out):
@@ -439,7 +439,7 @@ class TestGetAACGMCoordArr:
                                                self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.lat_in)
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.lat_in)
                 for oo in self.out]
 
         for i, oo in enumerate(self.out):
@@ -452,7 +452,7 @@ class TestGetAACGMCoordArr:
                                                self.dtime, self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.lat_in)
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.lat_in)
                 for oo in self.out]
 
         for i, oo in enumerate(self.out):
@@ -474,7 +474,7 @@ class TestGetAACGMCoordArr:
                                                self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
 
         self.ref = [64.34650424987989, 83.30339395305012, 0.3307388620896745]
         for i, oo in enumerate(self.out):
@@ -489,7 +489,7 @@ class TestGetAACGMCoordArr:
 
         
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == 1 for oo in self.out]
+        assert [isinstance(oo, np.ndarray) and len(oo) == 1 for oo in self.out]
         assert np.any([np.isnan(oo) for oo in self.out])
 
     def test_get_aacgm_coord_arr_time_failure(self):
@@ -517,7 +517,7 @@ class TestGetAACGMCoordArr:
                                                self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.lat_in)
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.lat_in)
                 for oo in self.out]
 
         for i, oo in enumerate(self.out):
@@ -532,7 +532,7 @@ class TestGetAACGMCoordArr:
                                                self.method)
 
         assert len(self.out) == len(self.ref)
-        assert [isinstance(oo, list) and len(oo) == len(self.lat_in)
+        assert [isinstance(oo, np.ndarray) and len(oo) == len(self.lat_in)
                 for oo in self.out]
         assert np.all(np.isnan(np.array(self.out)))
 

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -6,6 +6,7 @@ from io import StringIO
 import logging
 import numpy as np
 import os
+from sys import version_info
 import pytest
 import warnings
 
@@ -46,7 +47,8 @@ class TestConvertLatLon:
         self.out = aacgmv2.convert_latlon(*self.in_args)
         np.testing.assert_allclose(self.out, self.ref, rtol=self.rtol)
 
-    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
+    @pytest.mark.skipif(version_info.major == 2,
+                        reason='Not raised in Python 2')
     def test_convert_latlon_location_failure(self):
         """Test single value latlon conversion with a bad location"""
         self.out = aacgmv2.convert_latlon(0, 0, 0, self.dtime, self.in_args[-1])
@@ -224,7 +226,8 @@ class TestConvertLatLonArr:
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i]], rtol=self.rtol)
 
-    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
+    @pytest.mark.skipif(version_info.major == 2,
+                        reason='Not raised in Python 2')
     def test_convert_latlon_arr_location_failure(self):
         """Test array latlon conversion with a bad location"""
 
@@ -303,7 +306,8 @@ class TestGetAACGMCoord:
         self.out = aacgmv2.get_aacgm_coord(*self.in_args)
         np.testing.assert_allclose(self.out, self.ref, rtol=self.rtol)
 
-    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
+    @pytest.mark.skipif(version_info.major == 2,
+                        reason='Not raised in Python 2')
     def test_get_aacgm_coord_location_failure(self):
         """Test single value AACGMV2 calculation with a bad location"""
 
@@ -476,7 +480,8 @@ class TestGetAACGMCoordArr:
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, self.ref[i], rtol=self.rtol)
 
-    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
+    @pytest.mark.skipif(version_info.major == 2,
+                        reason='Not raised in Python 2')
     def test_get_aacgm_coord_arr_location_failure(self):
         """Test array AACGMV2 calculation with a bad location"""
         self.out = aacgmv2.get_aacgm_coord_arr([0], [0], [0], self.dtime,

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -6,10 +6,14 @@ from io import StringIO
 import logging
 import numpy as np
 import os
+from sys import version_info
 import pytest
 import warnings
 
 import aacgmv2
+
+if version_info.major == 2:
+    warnings.filterwarnings('error')
 
 class TestConvertLatLon:
     def setup(self):

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -6,14 +6,10 @@ from io import StringIO
 import logging
 import numpy as np
 import os
-from sys import version_info
 import pytest
 import warnings
 
 import aacgmv2
-
-if version_info.major == 2:
-    warnings.filterwarnings('error')
 
 class TestConvertLatLon:
     def setup(self):
@@ -50,6 +46,7 @@ class TestConvertLatLon:
         self.out = aacgmv2.convert_latlon(*self.in_args)
         np.testing.assert_allclose(self.out, self.ref, rtol=self.rtol)
 
+    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
     def test_convert_latlon_location_failure(self):
         """Test single value latlon conversion with a bad location"""
         self.out = aacgmv2.convert_latlon(0, 0, 0, self.dtime, self.in_args[-1])
@@ -227,6 +224,7 @@ class TestConvertLatLonArr:
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, [self.ref[i]], rtol=self.rtol)
 
+    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
     def test_convert_latlon_arr_location_failure(self):
         """Test array latlon conversion with a bad location"""
 
@@ -305,6 +303,7 @@ class TestGetAACGMCoord:
         self.out = aacgmv2.get_aacgm_coord(*self.in_args)
         np.testing.assert_allclose(self.out, self.ref, rtol=self.rtol)
 
+    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
     def test_get_aacgm_coord_location_failure(self):
         """Test single value AACGMV2 calculation with a bad location"""
 
@@ -477,6 +476,7 @@ class TestGetAACGMCoordArr:
         for i, oo in enumerate(self.out):
             np.testing.assert_allclose(oo, self.ref[i], rtol=self.rtol)
 
+    @pytest.mark.filterwarnings("ignore:AACGM_v2_Convert returned with error")
     def test_get_aacgm_coord_arr_location_failure(self):
         """Test array AACGMV2 calculation with a bad location"""
         self.out = aacgmv2.get_aacgm_coord_arr([0], [0], [0], self.dtime,

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -235,7 +235,7 @@ class TestConvertLatLonArr:
 
             # Test the output
             assert len(self.out) == len(self.ref)
-            assert np.any(np.isinf(np.array(self.out)))
+            assert np.any(~np.isfinite(np.array(self.out)))
 
     def test_convert_latlon_arr_mult_arr_unequal_failure(self):
         """Test array latlon conversion for unequal sized arrays"""

--- a/aacgmv2/tests/test_struct_aacgmv2.py
+++ b/aacgmv2/tests/test_struct_aacgmv2.py
@@ -100,7 +100,8 @@ class TestCStructure(TestModuleStructure):
         self.module_name = None
         self.reference_list = ["set_datetime", "convert", "inv_mlt_convert",
                                "inv_mlt_convert_yrsec", "mlt_convert",
-                               "mlt_convert_yrsec"]
+                               "mlt_convert_yrsec", "inv_mlt_convert_arr",
+                               "mlt_convert_arr", "convert_arr"]
 
     def teardown(self):
         del self.module_name, self.reference_list

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -393,8 +393,12 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
         raise RuntimeError("unable to set time for {:}: {:}".format(dtime,
                                                                     rerr))
 
-    lat_out, lon_out, r_out = c_aacgmv2.convert_arr(list(in_lat), list(in_lon),
-                                                    list(height), bit_code)
+    try:
+        lat_out, lon_out, r_out = c_aacgmv2.convert_arr(list(in_lat),
+                                                        list(in_lon),
+                                                        list(height), bit_code)
+    except SystemError as serr:
+        aacgmv2.logger.warning('C Error encountered: {:}'.format(serr))
 
     return lat_out, lon_out, r_out
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -401,7 +401,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
 
     return lat_out, lon_out, r_out
 
-def get_aacgm_coord(glat, glon, height, dtime, method="TRACE"):
+def get_aacgm_coord(glat, glon, height, dtime, method="ALLOWTRACE"):
     """Get AACGM latitude, longitude, and magnetic local time
 
     Parameters
@@ -445,7 +445,7 @@ def get_aacgm_coord(glat, glon, height, dtime, method="TRACE"):
     return mlat, mlon, mlt
 
 
-def get_aacgm_coord_arr(glat, glon, height, dtime, method="TRACE"):
+def get_aacgm_coord_arr(glat, glon, height, dtime, method="ALLOWTRACE"):
     """Get AACGM latitude, longitude, and magnetic local time
 
     Parameters

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -32,6 +32,10 @@ import aacgmv2
 import aacgmv2._aacgmv2 as c_aacgmv2
 from aacgmv2._aacgmv2 import TRACE, ALLOWTRACE, BADIDEA
 
+if sys.version_info.major == 2:
+    import warnings
+    warnings.filterwarnings('error')
+
 def test_time(dtime):
     """ Test the time input and ensure it is a dt.datetime object
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -312,8 +312,8 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
                            len(height.shape)])
     if test_array.min() == 0:
         if test_array.max() == 0:
-            aacgmv2.logger.warning("for a single location, consider using " \
-                                   "convert_latlon or get_aacgm_coord")
+            aacgmv2.logger.info("".join(["for a single location, consider ",
+                                    "using convert_latlon or get_aacgm_coord"]))
             in_lat = np.array([in_lat])
             in_lon = np.array([in_lon])
             height = np.array([height])

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -398,9 +398,23 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
                                                                     rerr))
 
     try:
-        lat_out, lon_out, r_out = c_aacgmv2.convert_arr(list(in_lat),
-                                                        list(in_lon),
-                                                        list(height), bit_code)
+        lat_out, lon_out, r_out, bad_ind = c_aacgmv2.convert_arr(list(in_lat),
+                                                                 list(in_lon),
+                                                                 list(height),
+                                                                 bit_code)
+        print(lat_out, lon_out, r_out)
+        # Cast the output as numpy arrays or masks
+        lat_out = np.array(lat_out)
+        lon_out = np.array(lon_out)
+        r_out = np.array(r_out)
+        bad_ind = np.array(bad_ind) >= 0
+
+        # Replace any bad indices with NaN, casting output as numpy arrays
+        if np.any(bad_ind):
+            print(lat_out, lon_out, r_out)
+            lat_out[bad_ind] = np.nan
+            lon_out[bad_ind] = np.nan
+            r_out[bad_ind] = np.nan
     except SystemError as serr:
         aacgmv2.logger.warning('C Error encountered: {:}'.format(serr))
 

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -457,8 +457,8 @@ def get_aacgm_coord(glat, glon, height, dtime, method="ALLOWTRACE"):
     mlat, mlon, _ = convert_latlon(glat, glon, height, dtime,
                                    method_code=method_code)
 
-    # Get magnetic local time
-    mlt = np.nan if np.isnan(mlon) else convert_mlt(mlon, dtime, m2a=False)
+    # Get magnetic local time (output is always an array, so extract value)
+    mlt = np.nan if np.isnan(mlon) else convert_mlt(mlon, dtime, m2a=False)[0]
 
     return mlat, mlon, mlt
 
@@ -662,8 +662,9 @@ def convert_mlt(arr, dtime, m2a=False):
         if len(arr) == 1:
             out = c_aacgmv2.mlt_convert(years[0], months[0], days[0], hours[0],
                                         minutes[0], seconds[0], arr[0])
+            out = np.array([out])
         else:
-            out = c_aacgmv2.mlt_convert_arr(years, months, days, hours, minutes,
-                                            seconds, arr)
+            out = np.array(c_aacgmv2.mlt_convert_arr(years, months, days, hours,
+                                                     minutes, seconds, arr))
 
-    return np.array(out)
+    return out

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -402,7 +402,7 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
                                                                  list(in_lon),
                                                                  list(height),
                                                                  bit_code)
-        print(lat_out, lon_out, r_out)
+
         # Cast the output as numpy arrays or masks
         lat_out = np.array(lat_out)
         lon_out = np.array(lon_out)
@@ -411,7 +411,6 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
 
         # Replace any bad indices with NaN, casting output as numpy arrays
         if np.any(bad_ind):
-            print(lat_out, lon_out, r_out)
             lat_out[bad_ind] = np.nan
             lon_out[bad_ind] = np.nan
             r_out[bad_ind] = np.nan
@@ -503,13 +502,13 @@ def get_aacgm_coord_arr(glat, glon, height, dtime, method="ALLOWTRACE"):
     mlat, mlon, _ = convert_latlon_arr(glat, glon, height, dtime,
                                        method_code=method_code)
 
-    if not np.all(np.isfinite(mlon)):
-        mlt = list(np.full(shape=len(mlat), fill_value=np.nan))
-    else:
+    if np.any(np.isfinite(mlon)):
         # Get magnetic local time
         mlt = convert_mlt(mlon, dtime, m2a=False)
         if not isinstance(mlt, type(mlat)):
-            mlt = [mlt]
+            mlt = np.array([mlt])
+    else:
+        mlt = np.full(shape=len(mlat), fill_value=np.nan)
 
     return mlat, mlon, mlt
 
@@ -667,4 +666,4 @@ def convert_mlt(arr, dtime, m2a=False):
             out = c_aacgmv2.mlt_convert_arr(years, months, days, hours, minutes,
                                             seconds, arr)
 
-    return out
+    return np.array(out)

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -481,11 +481,13 @@ def get_aacgm_coord_arr(glat, glon, height, dtime, method="ALLOWTRACE"):
     mlat, mlon, _ = convert_latlon_arr(glat, glon, height, dtime,
                                        method_code=method_code)
 
-    if np.all(np.isnan(mlon)):
-        mlt = np.full(shape=mlat.shape, fill_value=np.nan)
+    if not np.all(np.isfinite(mlon)):
+        mlt = list(np.full(shape=len(mlat), fill_value=np.nan))
     else:
         # Get magnetic local time
         mlt = convert_mlt(mlon, dtime, m2a=False)
+        if not isinstance(mlt, type(mlat)):
+            mlt = [mlt]
 
     return mlat, mlon, mlt
 
@@ -596,6 +598,9 @@ def convert_mlt(arr, dtime, m2a=False):
     if arr.shape == ():
         arr = np.array([arr])
 
+    if len(arr.shape) > 1:
+        raise ValueError("unable to process multi-dimensional arrays")
+
     # Test time
     try:
         dtime = test_time(dtime)
@@ -619,9 +624,6 @@ def convert_mlt(arr, dtime, m2a=False):
         minutes = [dd.minute for dd in dtime]
         seconds = [dd.second for dd in dtime]
 
-    if len(arr.shape) > 1:
-        raise ValueError("unable to process multi-dimensional arrays")
-        
     arr = list(arr)
 
     # Calculate desired location, C routines set date and time

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -304,6 +304,8 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
     that all successful calculations are returned.  To select only good values
     use a function like `np.isfinite`.
 
+    Multi-dimensional arrays are not allowed.
+
     """
 
     # Recast the data as numpy arrays
@@ -314,6 +316,9 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
     # If one or two of these elements is a float or int, create an array
     test_array = np.array([len(in_lat.shape), len(in_lon.shape),
                            len(height.shape)])
+    if test_array.max() > 1:
+        raise ValueError("unable to process multi-dimensional arrays")
+
     if test_array.min() == 0:
         if test_array.max() == 0:
             aacgmv2.logger.info("".join(["for a single location, consider ",
@@ -613,6 +618,10 @@ def convert_mlt(arr, dtime, m2a=False):
         hours = [dd.hour for dd in dtime]
         minutes = [dd.minute for dd in dtime]
         seconds = [dd.second for dd in dtime]
+
+    if len(arr.shape) > 1:
+        raise ValueError("unable to process multi-dimensional arrays")
+        
     arr = list(arr)
 
     # Calculate desired location, C routines set date and time

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,12 +94,12 @@ test_script:
 after_test:
   # if tagged commit, build/upload wheel
   - IF "%TOXENV%"=="2.7-buildonly-nocover" IF "%PYTHON_ARCH%"=="32" (%WITH_COMPILER% %TOXPYTHON% setup.py sdist)
-  - IF "%APPVEYOR_REPO_TAG%"=="true" IF NOT "%TOXENV%"=="%TOXENV:buildonly=%" (
-      %WITH_COMPILER% %TOXPYTHON% setup.py bdist_wheel &&
 ### Twine commands not working, remove for now
+#  - IF "%APPVEYOR_REPO_TAG%"=="true" IF NOT "%TOXENV%"=="%TOXENV:buildonly=%" (
+#      %WITH_COMPILER% %TOXPYTHON% setup.py bdist_wheel &&
 #      %PYTHON_HOME%\Scripts\pip install twine &&
 #      %PYTHON_HOME%\Scripts\twine upload -u %PYPI_USER% -p %PYPI_PASS% dist/*
-    )
+#    )
 
 on_failure:
   - ps: dir "env:"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,6 @@ environment:
       PYTHON_ARCH: '32'
     - TOXENV: '2.7-nocover'
       TOXPYTHON: C:\python27\python.exe
-
       PYTHON_HOME: C:\python27
       PYTHON_VERSION: '2.7'
       PYTHON_ARCH: '32'
@@ -60,7 +59,6 @@ environment:
       PYTHON_ARCH: '64'
     - TOXENV: '3.6-nocover'
       TOXPYTHON: C:\python36\python.exe
-
       PYTHON_HOME: C:\python36
       PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '32'
@@ -72,7 +70,6 @@ environment:
       PYTHON_ARCH: '64'
     - TOXENV: '3.7-nocover'
       TOXPYTHON: C:\python37\python.exe
-
       PYTHON_HOME: C:\python37
       PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '32'
@@ -99,8 +96,9 @@ after_test:
   - IF "%TOXENV%"=="2.7-buildonly-nocover" IF "%PYTHON_ARCH%"=="32" (%WITH_COMPILER% %TOXPYTHON% setup.py sdist)
   - IF "%APPVEYOR_REPO_TAG%"=="true" IF NOT "%TOXENV%"=="%TOXENV:buildonly=%" (
       %WITH_COMPILER% %TOXPYTHON% setup.py bdist_wheel &&
-      %PYTHON_HOME%\Scripts\pip install twine &&
-      %PYTHON_HOME%\Scripts\twine upload -u %PYPI_USER% -p %PYPI_PASS% dist/*
+### Twine commands not working, remove for now
+#      %PYTHON_HOME%\Scripts\pip install twine &&
+#      %PYTHON_HOME%\Scripts\twine upload -u %PYPI_USER% -p %PYPI_PASS% dist/*
     )
 
 on_failure:

--- a/tox.ini
+++ b/tox.ini
@@ -126,8 +126,9 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
-filterwarnings =
-    ignore::RuntimeWarning
+# No longer need this
+#filterwarnings =
+#    ignore::RuntimeWarning
 
 [testenv:2.7-nocover]
 basepython = {env:TOXPYTHON:python2.7}

--- a/tox.ini
+++ b/tox.ini
@@ -126,6 +126,8 @@ commands =
 deps =
     {[testenv]deps}
     pytest-cov
+filterwarnings =
+    ignore::RuntimeWarning
 
 [testenv:2.7-nocover]
 basepython = {env:TOXPYTHON:python2.7}


### PR DESCRIPTION
# Description

Moves the looping done in `convert_mlt`, `get_aacgm_coord_arr`, and `convert_latlon_arr` from python to C.

Fixes #42

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

The vectorization 'worked' for multidimensional arrays, while the new looping may only be performed on lists or 1-D arrays.  Additionally, some of the bad output is now `inf` instead of `nan`.  Both can be detected using `np.isfinite` rather than `np.isnan`.

# How Has This Been Tested?

Following the original test in the issue:

```
import datetime as dt
import aacgmv2
lat = [25.69817439, 17.14050096]
lon = [19.184186, -4.46442997]
alt = [465.28404149, 466.79848959]
method = 'geocentric|allowtrace'
dtime = dt.datetime(2014,12,7,16,17)
aacgmv2.get_aacgm_coord_arr(lat, lon, alt, dtime, method)
```
Provides:
```
Out: ([21.169912518324892, inf], [91.79687938812465, inf], [17.81387254816658, nan])
```

**Test Configuration**:
* OS X
* Python 2.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst``