### PR TITLE
Method code bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Changelog
 * Changed log warning about array functions to info
 * Changed default method from `TRACE` to `ALLOWTRACE`
 * Added C wrappers for list input, removing inefficient use of `np.vectorize`
+* Fixed documentation for use of `method_code`
+* Added deprecation warning for use of `code` keyword argument
 
 
 2.5.2 (2019-08-27)
@@ -18,6 +20,7 @@ Changelog
 * Removed logbook dependency
 * Added logic to avoid reseting environment variables if not necessary
 * Added copyright and license disclaimer to module-specific program files
+* Changed keyword argument `code` to `method_code`
   
 
 2.5.1 (2018-10-19)

--- a/aacgmv2/__init__.py
+++ b/aacgmv2/__init__.py
@@ -4,53 +4,22 @@
 # the root in the LICENSE file
 #
 # -*- coding: utf-8 -*-
-"""aacgmv2
+""" Functions to convert between geographic/geodetic and AACGM-V2 magnetic
+coordinates
 
-Modules
+Attributes
 ---------------------------------------------------------------------------
-_aacgmv2 : Contains functions and variables from c code
-deprecated : Contains deprecated functions from previous versions
-wrapper : Contains current python functions
----------------------------------------------------------------------------
+logger : (logger)
+    Logger handle
+high_alt_coeff : (float)
+    Upper altitude limit for using coefficients in km
+high_alt_trace : (float)
+    Upper altitude limit for using field-line tracing in km
+AACGM_V2_DAT_PREFIX : (str)
+    Location of AACGM-V2 coefficient files with the file prefix
+IGRF_12_COEFFS : (str)
+    Filename, with directory, of IGRF coefficients
 
-Parameters
----------------------------------------------------------------------------
-logger
-high_alt_coeff
-high_alt_trace
-AACGM_V2_DAT_PREFIX
-IGRF_12_COEFFS
-_aacgmv2.G2A
-_aacgmv2.A2G
-_aacgmv2.TRACE
-_aacgmv2.ALLOWTRACE
-_aacgmv2.BADIDEA
-_aacgmv2.GEOCENTRIC
----------------------------------------------------------------------------
-
-Functions
----------------------------------------------------------------------------
-convert_latlon_arr
-convert_str_to_bit
-convert_bool_to_bit
-get_aacgm_coord
-get_aacgm_coord_arr
-convert
-convert_mlt
-wrapper.set_coeff_path
-wrapper.test_height
-wrapper.test_time
-deprecated.subsol
-_aacgmv2.convert
-_aacgmv2.convert_arr
-_aacgmv2.set_datetime
-_aacgmv2.mlt_convert
-_aacgmv2.mlt_convert_arr
-_aacgmv2.mlt_convert_yrsec
-_aacgmv2.inv_mlt_convert
-_aacgmv2.inv_mlt_convert_arr
-_aacgmv2.inv_mlt_convert_yrsec
----------------------------------------------------------------------------
 """
 # Imports
 #---------------------------------------------------------------------

--- a/aacgmv2/__main__.py
+++ b/aacgmv2/__main__.py
@@ -96,12 +96,16 @@ def main():
                                            geocentric=args.geocentric)
         lats, lons, alts = aacgmv2.convert_latlon_arr(array[:, 0], array[:, 1],
                                                       array[:, 2], dtime=date,
-                                                      code=code)
+                                                      method_code=code)
         np.savetxt(args.file_out, np.column_stack((lats, lons, alts)),
                    fmt='%.8f')
     elif args.subcommand == 'convert_mlt':
         dtime = dt.datetime.strptime(args.datetime, '%Y%m%d%H%M%S')
-        out = aacgmv2.convert_mlt(array[:, 0], dtime, m2a=args.m2a)
+        out = np.array(aacgmv2.convert_mlt(array[:, 0], dtime, m2a=args.m2a))
+
+        if len(out.shape) == 0:
+            out = np.array([out])
+
         np.savetxt(args.file_out, out, fmt='%.8f')
 
 

--- a/aacgmv2/deprecated.py
+++ b/aacgmv2/deprecated.py
@@ -7,19 +7,10 @@
 """Pythonic wrappers for AACGM-V2 C functions that were depricated in the
 change from version 2.0.0 to version 2.0.2
 
-Functions
--------------------------------------------------------------------------------
-convert : Converts array location
-subsol : finds subsolar geocentric longitude and latitude
-gc2gd_lat : Convert between geocentric and geodetic coordinates
-igrf_dipole_axis : Get Cartesian unit vector pointing at the IGRF north dipole
-------------------------------------------------------------------------------
-
 References
 -------------------------------------------------------------------------------
 Laundal, K. M. and A. D. Richmond (2016), Magnetic Coordinate Systems, Space
  Sci. Rev., doi:10.1007/s11214-016-0275-y.
--------------------------------------------------------------------------------
 
 """
 

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -12,6 +12,76 @@ import warnings
 
 import aacgmv2
 
+class TestFutureDepWarning:
+    def setup(self):
+        # Initialize the routine to be tested
+        self.test_routine = None
+        self.test_args = []
+        self.test_kwargs = {}
+
+    def teardown(self):
+        del self.test_routine, self.test_args, self.test_kwargs
+
+    def test_future_dep_warning(self):
+        """Test the implementation of FutureWarning for deprecated kwargs"""
+        if self.test_routine is None:
+            assert True
+        else:
+            with warnings.catch_warnings(record=True) as wout:
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+
+                # Trigger a warning.
+                self.test_routine(*self.test_args, **self.test_kwargs)
+
+                # Verify some things
+                assert len(wout) == 1
+                assert issubclass(wout[-1].category, FutureWarning)
+                assert "Deprecated keyword" in str(wout[-1].message)
+
+class TestDepConvertWarning(TestFutureDepWarning):
+    def setup(self):
+        self.dtime = dt.datetime(2015, 1, 1, 0, 0, 0)
+        self.test_routine = None
+        self.test_args = []
+        self.test_kwargs = {}
+
+    def teardown(self):
+        del self.dtime, self.test_routine, self.test_args, self.test_kwargs
+
+    def test_convert_latlon_warning(self):
+        """Test future warning for convert_latlon"""
+
+        self.test_routine = aacgmv2.wrapper.convert_latlon
+        self.test_args = [60, 0, 300, self.dtime]
+        self.test_kwargs = {'code': 'TRACE'}
+        self.test_future_dep_warning()
+
+    def test_convert_latlon_arr_warning(self):
+        """Test future warning for convert_latlon_arr"""
+
+        self.test_routine = aacgmv2.wrapper.convert_latlon_arr
+        self.test_args = [60, 0, 300, self.dtime]
+        self.test_kwargs = {'code': 'TRACE'}
+        self.test_future_dep_warning()
+
+    def test_convert_latlon_time_error(self):
+        """Test single value latlon conversion with a bad datetime"""
+        self.test_routine = aacgmv2.wrapper.convert_latlon
+        self.test_args = [60, 0, 300, self.dtime]
+        self.test_kwargs = {'bad': 'keyword'}
+        with pytest.raises(TypeError):
+            self.test_routine(*self.test_args, **self.test_kwargs)
+
+    def test_convert_latlon_arr_time_error(self):
+        """Test single value latlon conversion with a bad datetime"""
+        self.test_routine = aacgmv2.wrapper.convert_latlon_arr
+        self.test_args = [60, 0, 300, self.dtime]
+        self.test_kwargs = {'bad': 'keyword'}
+        with pytest.raises(TypeError):
+            self.test_routine(*self.test_args, **self.test_kwargs)
+
+
 class TestConvertLatLon:
     def setup(self):
         """Runs before every method to create a clean testing setup"""

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -61,7 +61,7 @@ class TestDepConvertWarning(TestFutureDepWarning):
         """Test future warning for convert_latlon_arr"""
 
         self.test_routine = aacgmv2.wrapper.convert_latlon_arr
-        self.test_args = [60, 0, 300, self.dtime]
+        self.test_args = [[60, 60], [0, 0], [300, 300], self.dtime]
         self.test_kwargs = {'code': 'TRACE'}
         self.test_future_dep_warning()
 
@@ -76,7 +76,7 @@ class TestDepConvertWarning(TestFutureDepWarning):
     def test_convert_latlon_arr_time_error(self):
         """Test single value latlon conversion with a bad datetime"""
         self.test_routine = aacgmv2.wrapper.convert_latlon_arr
-        self.test_args = [60, 0, 300, self.dtime]
+        self.test_args = [[60, 60], [0, 0], [300, 300], self.dtime]
         self.test_kwargs = {'bad': 'keyword'}
         with pytest.raises(TypeError):
             self.test_routine(*self.test_args, **self.test_kwargs)

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -206,14 +206,15 @@ def convert_latlon(in_lat, in_lon, height, dtime, method_code="G2A", **kwargs):
 
     """
     # Handle deprecated keyword arguments
-    for kw, val in kwargs:
+    for kw in kwargs.keys():
         if kw not in ['code']:
             raise TypeError('unexpected keyword argument [{:s}]'.format(kw))
         else:
-            method_code = val
+            method_code = kwargs[kw]
             warnings.warn("".join(["Deprecated keyword argument 'code' will be",
-                                   " removed in version 2.5.4, please update ".
-                                   "your routine to use 'method_code'"]))
+                                   " removed in version 2.5.4, please update ",
+                                   "your routine to use 'method_code'"]),
+                          category=FutureWarning)
 
     # Test time
     dtime = test_time(dtime)
@@ -322,14 +323,15 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A",
 
     """
     # Handle deprecated keyword arguments
-    for kw, val in kwargs:
+    for kw in kwargs.keys():
         if kw not in ['code']:
             raise TypeError('unexpected keyword argument [{:s}]'.format(kw))
         else:
-            method_code = val
+            method_code = kwargs[kw]
             warnings.warn("".join(["Deprecated keyword argument 'code' will be",
-                                   " removed in version 2.5.4, please update ".
-                                   "your routine to use 'method_code'"]))
+                                   " removed in version 2.5.4, please update ",
+                                   "your routine to use 'method_code'"]),
+                          category=FutureWarning)
 
     # Recast the data as numpy arrays
     in_lat = np.array(in_lat)

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -27,13 +27,13 @@ import datetime as dt
 import numpy as np
 import os
 import sys
+import warnings
 
 import aacgmv2
 import aacgmv2._aacgmv2 as c_aacgmv2
 from aacgmv2._aacgmv2 import TRACE, ALLOWTRACE, BADIDEA
 
 if sys.version_info.major == 2:
-    import warnings
     warnings.filterwarnings('error')
 
 def test_time(dtime):
@@ -166,7 +166,7 @@ def set_coeff_path(igrf_file=False, coeff_prefix=False):
 
     return
 
-def convert_latlon(in_lat, in_lon, height, dtime, method_code="G2A"):
+def convert_latlon(in_lat, in_lon, height, dtime, method_code="G2A", **kwargs):
     """Converts between geomagnetic coordinates and AACGM coordinates
 
     Parameters
@@ -205,6 +205,15 @@ def convert_latlon(in_lat, in_lon, height, dtime, method_code="G2A"):
     TypeError or RuntimeError if unable to set AACGMV2 datetime
 
     """
+    # Handle deprecated keyword arguments
+    for kw, val in kwargs:
+        if kw not in ['code']:
+            raise TypeError('unexpected keyword argument [{:s}]'.format(kw))
+        else:
+            method_code = val
+            warnings.warn("".join(["Deprecated keyword argument 'code' will be",
+                                   " removed in version 2.5.4, please update ".
+                                   "your routine to use 'method_code'"]))
 
     # Test time
     dtime = test_time(dtime)
@@ -262,7 +271,8 @@ def convert_latlon(in_lat, in_lon, height, dtime, method_code="G2A"):
 
     return lat_out, lon_out, r_out
 
-def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
+def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A",
+                       **kwargs):
     """Converts between geomagnetic coordinates and AACGM coordinates.
 
     Parameters
@@ -311,6 +321,15 @@ def convert_latlon_arr(in_lat, in_lon, height, dtime, method_code="G2A"):
     Multi-dimensional arrays are not allowed.
 
     """
+    # Handle deprecated keyword arguments
+    for kw, val in kwargs:
+        if kw not in ['code']:
+            raise TypeError('unexpected keyword argument [{:s}]'.format(kw))
+        else:
+            method_code = val
+            warnings.warn("".join(["Deprecated keyword argument 'code' will be",
+                                   " removed in version 2.5.4, please update ".
+                                   "your routine to use 'method_code'"]))
 
     # Recast the data as numpy arrays
     in_lat = np.array(in_lat)

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -6,20 +6,6 @@
 # -*- coding: utf-8 -*-
 """Pythonic wrappers for AACGM-V2 C functions.
 
-Functions
---------------
-test_time : Test the time and ensure it is a datetime.datetime object
-test_height : Test the height and see if it is appropriate for the method
-set_coeff_path : Set the coefficient paths using default or supplied values
-convert_latlon : Converts scalar location
-convert_latlon_arr : Converts array location
-get_aacgm_coord : Get scalar magnetic lat, lon, mlt from geographic location
-get_aacgm_coord_arr : Get array magnetic lat, lon, mlt from geographic location
-convert_str_to_bit : Convert human readible AACGM flag to bits
-convert_bool_to_bit : Convert boolian flags to bits
-convert_mlt : Get array mlt
---------------
-
 """
 
 from __future__ import division, absolute_import, unicode_literals

--- a/docs/reference/cli.rst
+++ b/docs/reference/cli.rst
@@ -9,15 +9,15 @@ functions :py:func:`aacgmv2.convert_latlon_arr` and
 :py:func:`aacgmv2.convert_mlt`. See the documentation for these functions for a
 more thorough explanation of arguments and behaviour.
 
-You can get help on the two commands by running ``aacgmv2 convert -h`` and
-``aacgmv2 convert_mlt -h``.
+You can get help on the two commands by running ``python aacgmv2 convert -h``
+and ``python aacgmv2 convert_mlt -h``.
 
 convert
 -------
 
 .. code::
 
-    $ aacgmv2 convert -h
+    $ python aacgmv2 convert -h
     usage: aacgmv2 convert [-h] [-i FILE_IN] [-o FILE_OUT] [-d YYYYMMDD] [-v] [-t]
                            [-a] [-b] [-g]
 
@@ -43,7 +43,7 @@ convert_mlt
 
 .. code::
 
-    $ aacgmv2 convert_mlt -h
+    $ python aacgmv2 convert_mlt -h
     usage: aacgmv2 convert_mlt [-h] [-i FILE_IN] [-o FILE_OUT] [-v] YYYYMMDDHHMMSS
 
     positional arguments:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -5,7 +5,8 @@ Usage examples
 Python library
 ==============
 
-For full documentation of the functions, see :doc:`Reference → aacgmv2 <reference/aacgmv2>`.
+For full documentation of the functions, see
+:doc:`Reference → aacgmv2 <reference/aacgmv2>`.
 
 For examples on converting between AACGM and geographic coordinates and AACGM
 and MLT, see :doc:`Overview → Quick Start <readme>`.
@@ -61,9 +62,9 @@ you're converting)::
     23
 
 To convert these MLTs to magnetic longitudes at 2015-02-24 14:00:15, run e.g.
-``aacgmv2 convert_mlt 20150224140015 -i input.txt -o output.txt -v`` (note that
-the date/time is a required parameter). The output file will then look like
-this::
+``python aacgmv2 convert_mlt 20150224140015 -i input.txt -o output.txt -v``
+(note that the date/time is a required parameter). The output file will then
+look like this::
 
     -120.34354125
     44.65645875


### PR DESCRIPTION
# Description

1) update the documentation
2) update the changelog
3) add an option to use code, but its use will trigger a deprecation warning that the user should switch to method_code
4) schedule the removal of code for the release of version 2.5.4

Fixes #44 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

To verify this change, run the following code:

```
import aacgmv2
import datetime as dt
import numpy as np
dtime = dt.datetime(2013, 11, 3)

# For python 2 I needed this:
import warnings
warnings.filterwarnings('default')

# For everyone
aacgmv2.convert_latlon(60, 15, 300, dtime, code='COEFF')
```

This will throw a warning, but give output:
> aacgmv2/wrapper.py:203: FutureWarning: Deprecated keyword argument 'code' will be removed in version 2.5.4, please update your routine to use 'method_code'
  category=FutureWarning)
> Out[7]: (57.47207691280528, 93.62138045643165, 1.045663455639381)

Then try: `aacgmv2.convert_latlon(60, 15, 300, dtime, method_code='COEFF')`
and get `(57.47207691280528, 93.62138045643165, 1.045663455639381)`.

**Test Configuration**:
* Operating system: OS X
* Version number: 2.5.2 method_code_bug
* Any details about your local setup that are relevant: Tested on python 2.7 and 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst``