### PR TITLE
Fixed memory leak

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 * Updated unit tests to current pytest standards
 * Updated links in the documentation
 * Improved the documentation style and added docstring tests
+* Fixed memory leak in the array C wrappers
 
 2.6.2 (2020-01-13)
 ------------------

--- a/aacgmv2/aacgmv2module.c
+++ b/aacgmv2/aacgmv2module.c
@@ -107,10 +107,7 @@ static PyObject *aacgm_v2_convert_arr(PyObject *self, PyObject *args)
   /* Set the output tuple */
   allOut = PyTuple_Pack(4, latOut, lonOut, rOut, badOut);
 
-  /* Free memory */
-  Py_DECREF(latIn);
-  Py_DECREF(lonIn);
-  Py_DECREF(hIn);
+  /* Free memory for the local-only (not input) variables */
   Py_DECREF(latOut);
   Py_DECREF(lonOut);
   Py_DECREF(rOut);
@@ -182,15 +179,6 @@ static PyObject *mltconvert_v2_arr(PyObject *self, PyObject *args)
       
       PyList_SetItem(mltOut, i, PyFloat_FromDouble(out_mlt));
     }
-
-  /* Free memory */
-  Py_DECREF(yrIn);
-  Py_DECREF(moIn);
-  Py_DECREF(dyIn);
-  Py_DECREF(hrIn);
-  Py_DECREF(mtIn);
-  Py_DECREF(scIn);
-  Py_DECREF(lonIn);
 
   return mltOut;
 }
@@ -266,15 +254,6 @@ static PyObject *inv_mltconvert_v2_arr(PyObject *self, PyObject *args)
       
       PyList_SetItem(lonOut, i, PyFloat_FromDouble(out_lon));
     }
-
-  /* Free memory */
-  Py_DECREF(yrIn);
-  Py_DECREF(moIn);
-  Py_DECREF(dyIn);
-  Py_DECREF(hrIn);
-  Py_DECREF(mtIn);
-  Py_DECREF(scIn);
-  Py_DECREF(mltIn);
 
   return lonOut;
 }

--- a/aacgmv2/aacgmv2module.c
+++ b/aacgmv2/aacgmv2module.c
@@ -53,9 +53,9 @@ static PyObject *aacgm_v2_setdatetime(PyObject *self, PyObject *args)
 
 static PyObject *aacgm_v2_convert_arr(PyObject *self, PyObject *args)
 {
-  int i, code, err;
+  int code, err;
 
-  long int in_num;
+  long int i, in_num;
 
   double in_lat, in_lon, in_h, out_lat, out_lon, out_r;
 
@@ -88,7 +88,8 @@ static PyObject *aacgm_v2_convert_arr(PyObject *self, PyObject *args)
       /* Set the output */
       if(err < 0)
 	{
-	  /* Python 3.7+ raises a SystemError when passing on inf */
+	  /* Python 3.7+ raises a SystemError when passing on inf. */
+	  /* SetItem STEALS the references that are added.         */
 	  PyList_SetItem(badOut, i, PyLong_FromLong((int long)i));
 	  PyList_SetItem(latOut, i, PyFloat_FromDouble(-666.0));
 	  PyList_SetItem(lonOut, i, PyFloat_FromDouble(-666.0));

--- a/aacgmv2/aacgmv2module.c
+++ b/aacgmv2/aacgmv2module.c
@@ -182,6 +182,15 @@ static PyObject *mltconvert_v2_arr(PyObject *self, PyObject *args)
       PyList_SetItem(mltOut, i, PyFloat_FromDouble(out_mlt));
     }
 
+  /* Free memory */
+  Py_DECREF(yrIn);
+  Py_DECREF(moIn);
+  Py_DECREF(dyIn);
+  Py_DECREF(hrIn);
+  Py_DECREF(mtIn);
+  Py_DECREF(scIn);
+  Py_DECREF(lonIn);
+
   return mltOut;
 }
 
@@ -256,6 +265,15 @@ static PyObject *inv_mltconvert_v2_arr(PyObject *self, PyObject *args)
       
       PyList_SetItem(lonOut, i, PyFloat_FromDouble(out_lon));
     }
+
+  /* Free memory */
+  Py_DECREF(yrIn);
+  Py_DECREF(moIn);
+  Py_DECREF(dyIn);
+  Py_DECREF(hrIn);
+  Py_DECREF(mtIn);
+  Py_DECREF(scIn);
+  Py_DECREF(mltIn);
 
   return lonOut;
 }

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -70,8 +70,11 @@ class TestCAACGMV2(object):
     def test_fail_set_datetime(self):
         """Test unsuccessful set_datetime."""
         self.long_date[0] = 1013
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as rerr:
             aacgmv2._aacgmv2.set_datetime(*self.long_date)
+
+        assert str(rerr).find(
+            "AACGM_v2_SetDateTime returned error code -1") >= 0
 
     @pytest.mark.parametrize('idate,ckey', [(0, 'G2A'), (1, 'G2A'),
                                             (0, 'A2G'), (1, 'A2G'),
@@ -129,16 +132,20 @@ class TestCAACGMV2(object):
     def test_forbidden(self):
         """Test convert failure."""
         self.lat_in[0] = 7
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as rerr:
             aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0], 0,
                                      aacgmv2._aacgmv2.G2A)
+
+        assert str(rerr).find("AACGM_v2_Convert returned error code -1") >= 0
 
     def test_convert_high_denied(self):
         """Test for failure when converting to high alt geod to mag coords."""
         aacgmv2._aacgmv2.set_datetime(*self.date_args[0])
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError) as rerr:
             aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0], 5500,
                                      aacgmv2._aacgmv2.G2A)
+
+        assert str(rerr).find("AACGM_v2_Convert returned error code -4") >= 0
 
     @pytest.mark.parametrize('code,lat_comp,lon_comp,r_comp',
                              [(aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE,
@@ -229,6 +236,15 @@ class TestCAACGMV2(object):
         self.mlon = aacgmv2._aacgmv2.inv_mlt_convert(*self.long_date)
         np.testing.assert_almost_equal(self.mlon, mlt_comp, decimal=4)
 
+    def test_inv_mlt_convert_arr(self):
+        """Test array MLT inversion."""
+        self.date_args = [[ldate for j in range(3)] for ldate in self.long_date]
+        self.mlt = [12.0, 25.0, -1.0]
+        self.lon_in = [-153.6033, 41.3967, 11.3967]
+        self.mlon = aacgmv2._aacgmv2.inv_mlt_convert_arr(*self.date_args,
+                                                         self.mlt)
+        np.testing.assert_almost_equal(self.mlon, self.lon_in, decimal=4)
+
     @pytest.mark.parametrize('marg,mlt_comp',
                              [(12.0, -153.6033), (25.0, 41.3967),
                               (-1.0, 11.3967)])
@@ -272,6 +288,14 @@ class TestCAACGMV2(object):
         mlt_args.append(marg)
         self.mlt = aacgmv2._aacgmv2.mlt_convert(*mlt_args)
         np.testing.assert_almost_equal(self.mlt, mlt_comp, decimal=4)
+
+    def test_mlt_convert_arr(self):
+        """Test array MLT conversion."""
+        self.date_args = [[ldate for j in range(3)] for ldate in self.long_date]
+        self.mlon = [-153.6033, 41.3967, 11.3967]
+        self.lon_in = [12.0, 1.0, 23.0]
+        self.mlt = aacgmv2._aacgmv2.mlt_convert_arr(*self.date_args, self.mlon)
+        np.testing.assert_almost_equal(self.mlt, self.lon_in, decimal=4)
 
     @pytest.mark.parametrize('marg,mlt_comp',
                              [(270.0, 16.2402), (80.0, 3.5736),

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -73,8 +73,8 @@ class TestCAACGMV2(object):
         with pytest.raises(RuntimeError) as rerr:
             aacgmv2._aacgmv2.set_datetime(*self.long_date)
 
-        assert str(rerr).find(
-            "AACGM_v2_SetDateTime returned error code -1") >= 0
+        if str(rerr).find("AACGM_v2_SetDateTime returned error code -1") < 0:
+            raise AssertionError('unknown error message: {:}'.format(str(rerr))
 
     @pytest.mark.parametrize('idate,ckey', [(0, 'G2A'), (1, 'G2A'),
                                             (0, 'A2G'), (1, 'A2G'),
@@ -136,7 +136,8 @@ class TestCAACGMV2(object):
             aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0], 0,
                                      aacgmv2._aacgmv2.G2A)
 
-        assert str(rerr).find("AACGM_v2_Convert returned error code -1") >= 0
+        if str(rerr).find("AACGM_v2_Convert returned error code -1") < 0:
+            raise AssertionError('unknown error message: {:}'.format(str(rerr))
 
     def test_convert_high_denied(self):
         """Test for failure when converting to high alt geod to mag coords."""
@@ -145,7 +146,8 @@ class TestCAACGMV2(object):
             aacgmv2._aacgmv2.convert(self.lat_in[0], self.lon_in[0], 5500,
                                      aacgmv2._aacgmv2.G2A)
 
-        assert str(rerr).find("AACGM_v2_Convert returned error code -4") >= 0
+        if str(rerr).find("AACGM_v2_Convert returned error code -4") < 0:
+            raise AssertionError('unknown error message: {:}'.format(str(rerr))
 
     @pytest.mark.parametrize('code,lat_comp,lon_comp,r_comp',
                              [(aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE,

--- a/aacgmv2/tests/test_c_aacgmv2.py
+++ b/aacgmv2/tests/test_c_aacgmv2.py
@@ -14,6 +14,7 @@ class TestCAACGMV2(object):
         self.mlat = None
         self.mlon = None
         self.rshell = None
+        self.bad_ind = None
         self.mlt = None
         self.lat_in = [45.5, 60]
         self.lon_in = [-23.5, 0]
@@ -33,7 +34,7 @@ class TestCAACGMV2(object):
         """Run after every method to clean up previous testing."""
         del self.date_args, self.long_date, self.mlat, self.mlon, self.mlt
         del self.lat_in, self.lon_in, self.alt_in, self.lat_comp, self.lon_comp
-        del self.r_comp, self.code
+        del self.r_comp, self.code, self.bad_ind
 
     @pytest.mark.parametrize('mattr,val', [(aacgmv2._aacgmv2.G2A, 0),
                                            (aacgmv2._aacgmv2.A2G, 1),
@@ -74,7 +75,7 @@ class TestCAACGMV2(object):
             aacgmv2._aacgmv2.set_datetime(*self.long_date)
 
         if str(rerr).find("AACGM_v2_SetDateTime returned error code -1") < 0:
-            raise AssertionError('unknown error message: {:}'.format(str(rerr))
+            raise AssertionError('unknown error message: {:}'.format(str(rerr)))
 
     @pytest.mark.parametrize('idate,ckey', [(0, 'G2A'), (1, 'G2A'),
                                             (0, 'A2G'), (1, 'A2G'),
@@ -116,9 +117,9 @@ class TestCAACGMV2(object):
         """
         aacgmv2._aacgmv2.set_datetime(*self.date_args[0])
         (self.mlat, self.mlon, self.rshell,
-         bad_ind) = aacgmv2._aacgmv2.convert_arr(self.lat_in, self.lon_in,
-                                                 self.alt_in,
-                                                 self.code[ckey])
+         self.bad_ind) = aacgmv2._aacgmv2.convert_arr(self.lat_in, self.lon_in,
+                                                      self.alt_in,
+                                                      self.code[ckey])
 
         np.testing.assert_equal(len(self.mlat), len(self.lat_in))
         np.testing.assert_almost_equal(self.mlat[0], self.lat_comp[ckey][0],
@@ -127,7 +128,7 @@ class TestCAACGMV2(object):
                                        decimal=4)
         np.testing.assert_almost_equal(self.rshell[0], self.r_comp[ckey][0],
                                        decimal=4)
-        np.testing.assert_equal(bad_ind[0], -1)
+        np.testing.assert_equal(self.bad_ind[0], -1)
 
     def test_forbidden(self):
         """Test convert failure."""
@@ -137,7 +138,7 @@ class TestCAACGMV2(object):
                                      aacgmv2._aacgmv2.G2A)
 
         if str(rerr).find("AACGM_v2_Convert returned error code -1") < 0:
-            raise AssertionError('unknown error message: {:}'.format(str(rerr))
+            raise AssertionError('unknown error message: {:}'.format(str(rerr)))
 
     def test_convert_high_denied(self):
         """Test for failure when converting to high alt geod to mag coords."""
@@ -147,7 +148,7 @@ class TestCAACGMV2(object):
                                      aacgmv2._aacgmv2.G2A)
 
         if str(rerr).find("AACGM_v2_Convert returned error code -4") < 0:
-            raise AssertionError('unknown error message: {:}'.format(str(rerr))
+            raise AssertionError('unknown error message: {:}'.format(str(rerr)))
 
     @pytest.mark.parametrize('code,lat_comp,lon_comp,r_comp',
                              [(aacgmv2._aacgmv2.G2A + aacgmv2._aacgmv2.TRACE,

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -860,7 +860,10 @@ class TestPyLogging(object):
 
     def eval_logger_message(self):
         """Evaluate the logger message."""
-        assert self.lout.find(self.lwarn) >= 0, "unknown logger message"
+        if self.lout.find(self.lwarn) < 0:
+            raise AssertionError(
+                "unknown logger message: {:} not in {:}".format(self.lwarn,
+                                                                self.lout))
 
     def test_warning_below_ground(self, caplog):
         """Test that a warning is issued if height < 0 for height test."""

--- a/aacgmv2/tests/test_py_aacgmv2.py
+++ b/aacgmv2/tests/test_py_aacgmv2.py
@@ -153,6 +153,23 @@ class TestConvertLatLon(object):
 class TestConvertLatLonArr(TestConvertArray):
     """Unit tests for Lat/Lon array conversion."""
 
+    def test_convert_latlon_arr_large(self):
+        """Test array latlon conversion for a large array."""
+        # Update input
+        self.lat_in = np.full(shape=(6000,), fill_value=self.lat_in[0])
+        self.lon_in = np.full(shape=(6000,), fill_value=self.lon_in[0])
+
+        # Update expected output
+        self.ref[0] = np.full(shape=(6000,), fill_value=self.ref[0][0])
+        self.ref[1] = np.full(shape=(6000,), fill_value=self.ref[1][0])
+        self.ref[2] = np.full(shape=(6000,), fill_value=1.0457)
+
+        # Run the conversion and evaluate
+        self.out = aacgmv2.convert_latlon_arr(self.lat_in, self.lon_in,
+                                              self.alt_in[0], self.dtime,
+                                              self.method)
+        self.evaluate_output()
+        
     def test_convert_latlon_arr_single_val(self):
         """Test array latlon conversion for a single value."""
         self.out = aacgmv2.convert_latlon_arr(self.lat_in[0], self.lon_in[0],
@@ -388,6 +405,24 @@ class TestGetAACGMCoord(object):
 class TestGetAACGMCoordArr(TestConvertArray):
     """Unit tests for AACGM coordinate array conversion."""
 
+    def test_get_aacgm_coord_arr_large(self):
+        """Test array conversion for a large array."""
+        # Update input
+        self.lat_in = np.full(shape=(6000,), fill_value=self.lat_in[0])
+        self.lon_in = np.full(shape=(6000,), fill_value=self.lon_in[0])
+        self.alt_in = np.full(shape=(6000,), fill_value=self.alt_in[0])
+
+        # Update expected output
+        self.ref[0] = np.full(shape=(6000,), fill_value=self.ref[0][0])
+        self.ref[1] = np.full(shape=(6000,), fill_value=self.ref[1][0])
+        self.ref[2] = np.full(shape=(6000,), fill_value=self.ref[2][0])
+
+        # Run the conversion and evaluate
+        self.out = aacgmv2.get_aacgm_coord_arr(self.lat_in, self.lon_in,
+                                               self.alt_in, self.dtime,
+                                               self.method)
+        self.evaluate_output()
+    
     def test_get_aacgm_coord_arr_single_val(self):
         """Test array AACGMV2 calculation for a single value."""
         self.out = aacgmv2.get_aacgm_coord_arr(self.lat_in[0], self.lon_in[0],

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -9,7 +9,6 @@
 import datetime as dt
 import numpy as np
 import os
-import sys
 
 import aacgmv2
 import aacgmv2._aacgmv2 as c_aacgmv2

--- a/aacgmv2/wrapper.py
+++ b/aacgmv2/wrapper.py
@@ -240,11 +240,11 @@ def convert_latlon(in_lat, in_lon, height, dtime, method_code="G2A"):
     try:
         lat_out, lon_out, r_out = c_aacgmv2.convert(in_lat, in_lon, height,
                                                     bit_code)
-    except Exception:
-        err = sys.exc_info()[0]
-        estr = "unable to perform conversion at {:.1f},".format(in_lat)
-        estr = "{:s}{:.1f} {:.1f} km, {:} ".format(estr, in_lon, height, dtime)
-        estr = "{:s}using method {:}: {:}".format(estr, bit_code, err)
+    except Exception as err:
+        estr = "".join(["unable to perform conversion at {:.1f}".format(in_lat),
+                        ", {:.1f} {:.1f} km, {:}".format(in_lon, height, dtime),
+                        " using method {:} <{:}>. Recall".format(bit_code, err),
+                        " that AACGMV2 is undefined near the equator."])
         aacgmv2.logger.warning(estr)
         pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,37 @@
 [metadata]
+name = aacgmv2
 version = 2.6.2
-long_description= = file: README.rst, CHANGELOG.rst
+license = file: LICENSE
+long_description = file: README.rst, CHANGELOG.rst
 long_description_content_type = text/x-rst,
+readme = file: README.rst
+keywords = aacgm
+	   aacgm-v2
+           aacgmv2
+           magnetic coordinates
+           altitude adjusted corrected geomagnetic coordinates
+           mlt
+           magnetic local time
+           conversion
+           converting
+classifiers = 
+   Development Status :: 5 - Production/Stable
+   Intended Audience :: Science/Research
+   License :: OSI Approved :: MIT License
+   Operating System :: Unix
+   Operating System :: POSIX
+   Operating System :: MacOS :: MacOS X
+   Operating System :: Microsoft :: Windows
+   Programming Language :: Python
+   Programming Language :: Python :: 3
+   Programming Language :: Python :: 3.7
+   Programming Language :: Python :: 3.8
+   Programming Language :: Python :: 3.9
+   Programming Language :: Python :: 3.10
+   Programming Language :: Python :: Implementation :: CPython
+   Topic :: Software Development :: Libraries
+   Topic :: Scientific/Engineering :: Physics
+   Topic :: Utilities
 
 [options]
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,10 +51,9 @@ python_files =
     tests.py
 addopts =
     -rxEfsw
-    --strict
+    --strict-markers
     --ignore=docs/conf.py
     --ignore=setup.py
-    --ignore=ci
     --ignore=.eggs
     --doctest-modules
     --doctest-glob=\*.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,8 @@
 [metadata]
 name = aacgmv2
 version = 2.6.2
-license = file: LICENSE
 long_description = file: README.rst, CHANGELOG.rst
-long_description_content_type = text/x-rst,
-readme = file: README.rst
+long_description_content_type = text/x-rst
 keywords = aacgm
 	   aacgm-v2
            aacgmv2


### PR DESCRIPTION
# Description

There was a memory leak due to a lack of freeing PyObject pointers in the C code.  Fixes #74 and #75 by clarifying the existing logger message.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Make sure to re-install AACGMV2 before testing, since the C code has to be re-compiled.  Also added two new unit tests that would have segfaulted previously.

```
import timeit

# Yields 15.579 s on my system
timeit.timeit("import aacgmv2; import datetime; import numpy as np; rando_lat = np.random.uniform(low=-90,high=90,size=6000); rando_long = np.random.uniform(low=-180,high=180,size=6000);aacgmv2.convert_latlon_arr(rando_lat, rando_long, 350.0, datetime.datetime(2015, 5, 5), method_code='G2A')", number=1000)

# Yields 1866.4816 on my system
timeit.timeit("import aacgmv2; import datetime; import numpy as np; rando_lat = np.random.uniform(low=-90,high=90,size=6000); rando_long = np.random.uniform(low=-180,high=180,size=6000);aacgmv2.get_aacgm_coord_arr(rando_lat, rando_long, 350.0, datetime.datetime(2015, 5, 5), method='G2A')", number=1000)

# Yields x s on my system
timeit.timeit("import aacgmv2; import datetime; import numpy as np; rando_lon = np.random.uniform(low=-180,high=180,size=6000);aacgmv2.convert_mlt(rando_lon, datetime.datetime(2015, 5, 5), m2a=False)")

```



**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``Changelog.rst``, summarising the changes
- [x] Add yourself to ``AUTHORS.rst``